### PR TITLE
Handle External Files

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/CSProjectInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/CSProjectInfo.cs
@@ -255,6 +255,10 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 case AssetLocation.PackageCopy:
                     relativeSourcePath = $"..\\{Utilities.GetPackagesRelativePathFrom(sourceFile.File.FullName)}";
                     break;
+                case AssetLocation.External:
+                    relativeSourcePath = sourceFile.File.FullName;
+                    Debug.LogWarning($"Referencing external source file with full path '{sourceFile.File.FullName}'");
+                    break;
                 default: throw new InvalidDataException("Unknown asset location.");
             }
 

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Utilities.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Utilities.cs
@@ -38,7 +38,12 @@ namespace Microsoft.Build.Unity.ProjectGeneration
         /// <summary>
         /// Inside the Packages folder shipped with the Unity version.
         /// </summary>
-        BuiltInPackage
+        BuiltInPackage,
+
+        /// <summary>
+        /// The asset is located external to any known projects, but is somehow pulled in.
+        /// </summary>
+        External
     }
 
     /// <summary>
@@ -174,7 +179,8 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             }
             else
             {
-                throw new InvalidDataException($"Unknown asset location for '{absolutePath}'");
+                Debug.LogWarning($"Unknown asset location for '{absolutePath}', marking as external.");
+                return AssetLocation.External;
             }
         }
 


### PR DESCRIPTION
This is for the case where a UPM package is referenced as a file path, the actual files are external to any known Unity path. It's a super rare case, as UPM packages shouldn't be consumed that way, so printing a warning.