### PR TITLE
Generate BuildProjects.proj Helper

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/BuildProjects.proj.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/BuildProjects.proj.template
@@ -1,0 +1,26 @@
+<Project>
+<!-- xmlns="http://schemas.microsoft.com/developer/msbuild/2003"-->
+  <PropertyGroup>
+    <TargetProjectName><!--TARGET_PROJECT_NAME_TOKEN--></TargetProjectName>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReferences  Include="Projects\$(TargetProjectName).sln"/>
+  </ItemGroup>
+
+<!--PLATFORM_TARGET_TEMPLATE_START-->
+  <Target Name="Build##PLATFORM_TOKEN####CONFIGURATION_TOKEN##">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=##CONFIGURATION_TOKEN##;Platform=##PLATFORM_TOKEN##;BuildProjectReferences=false">
+      <Output TaskParameter="TargetOutputs" ItemName="Build##PLATFORM_TOKEN####CONFIGURATION_TOKEN##Outputs" />
+    </MSBuild>
+  </Target>
+<!--PLATFORM_TARGET_TEMPLATE_END-->
+
+  <!-- WSA Player is special cased-->
+  <Target Name="BuildWSAPlayer">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=WSA;BuildProjectReferences=false;MSBuildExtensionsPathOverride=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild">
+      <Output TaskParameter="TargetOutputs" ItemName="BuildWSAPlayerOutputs" />
+    </MSBuild>
+  </Target>
+  
+</Project>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/BuildProjects.proj.template.meta
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/BuildProjects.proj.template.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4228d635102da7a4fa5864cfad207d1c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/TemplateFiles.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/TemplateFiles.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
         private const string EditorPropsTemplateName = "Editor.InEditor.Template.props.template";
         private const string SpecifcPlatformPropsTemplateRegex = @"[a-zA-Z]+\.[a-zA-Z]+\.Template\.props.template";
         private const string PluginMetaFileTemplateRegex = @"Plugin\.([a-zA-Z]*)\.meta.template";
+        private const string BuildProjectsTemplateName = "BuildProjects.proj.template";
 
         private static TemplateFiles instance;
 
@@ -47,6 +48,11 @@ namespace Microsoft.Build.Unity.ProjectGeneration
         /// Gets the MSBuild Platform Props file (.props) template path.
         /// </summary>
         public string PlatformPropsTemplatePath { get; }
+
+        /// <summary>
+        /// Gets the BuildProjects.proj MSBuild file template path.
+        /// </summary>
+        public string BuildProjectsTemplatePath { get; }
 
         /// <summary>
         /// Gets a list of specialized platform templates.
@@ -78,13 +84,14 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             }
 
             string[] files = AssetDatabase.FindAssets("*", templateFolders);
-            Utilities.GetPathsFromGuidsInPlace(files, fullPaths: true); 
+            Utilities.GetPathsFromGuidsInPlace(files, fullPaths: true);
 
             Dictionary<string, string> fileNamesMaps = files.ToDictionary(t => Path.GetFileName(t));
 
             MSBuildSolutionTemplatePath = GetExpectedTemplatesPath(fileNamesMaps, "MSBuild Solution", MSBuildSolutionTemplateName);
             SDKProjectFileTemplatePath = GetExpectedTemplatesPath(fileNamesMaps, "SDK Project", SDKProjectFileTemplateName);
             PlatformPropsTemplatePath = GetExpectedTemplatesPath(fileNamesMaps, "Platform Props", PlatformPropsTemplateName);
+            BuildProjectsTemplatePath = GetExpectedTemplatesPath(fileNamesMaps, "MSBuild Build Projects Proj", BuildProjectsTemplateName);
 
             // Get specific platforms
             Dictionary<string, string> platformTemplates = new Dictionary<string, string>();


### PR DESCRIPTION
Added a quick generator of BuildProjects.proj MSBuild file to enable invoking the builds with:
dotnet msbuild BuildProjects.proj /t:Build<Platform><Config>.

And a quick bat file to build it all.