### PR TITLE
Migrate Fix from MRTK

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/SDKProjectTemplate.csproj.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/SDKProjectTemplate.csproj.template
@@ -76,8 +76,13 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   
   <PropertyGroup>
-      <AssemblySearchPaths>{CandidateAssemblyFiles};{HintPathFromItem};{RawFileName};</AssemblySearchPaths>
+    <!-- 
+      This overrides the default, and excludes the "{TargetFrameworkDirectory}" from the search path which gets added by the import above.
+      The purpose is to prevent MSBuild from using it to try and resolve assemblies from that location, as we use the Unity provided framework DLLs.
+    -->
+    <AssemblySearchPaths>{CandidateAssemblyFiles};{HintPathFromItem};{RawFileName};</AssemblySearchPaths>
   </PropertyGroup>
+  
   <Import Project="##PLATFORM_PROPS_FOLDER_PATH_TOKEN##\$(UnityPlatform).$(UnityConfiguration).props"/>
 
   <!-- This is a "special" platform that will override references -->
@@ -94,6 +99,7 @@
   
   <PropertyGroup>
     <DefaultItemExcludes>$(DefaultItemExcludes)obj;bin;*.asmdef;*.asmdef.meta;*.csmap;</DefaultItemExcludes>
+    <!-- This change prevents from System.Core dll to be removed and readded without the HintPath as is default behaviour for some MSBuild environments for System.Core.dll specifically.-->
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
   </PropertyGroup>
 

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/SDKProjectTemplate.csproj.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/SDKProjectTemplate.csproj.template
@@ -75,6 +75,9 @@
   <!--IMPORT SDK.props manually to be able to set the BaseIntermediateOutputPath above path-->
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   
+  <PropertyGroup>
+      <AssemblySearchPaths>{CandidateAssemblyFiles};{HintPathFromItem};{RawFileName};</AssemblySearchPaths>
+  </PropertyGroup>
   <Import Project="##PLATFORM_PROPS_FOLDER_PATH_TOKEN##\$(UnityPlatform).$(UnityConfiguration).props"/>
 
   <!-- This is a "special" platform that will override references -->
@@ -91,6 +94,7 @@
   
   <PropertyGroup>
     <DefaultItemExcludes>$(DefaultItemExcludes)obj;bin;*.asmdef;*.asmdef.meta;*.csmap;</DefaultItemExcludes>
+    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
   </PropertyGroup>
 
 <!--PROJECT_REFERENCE_SET_TEMPLATE_START-->


### PR DESCRIPTION
Last week MRTK builds encountered an issue with their generated projects after a software update was pushed to the build machines. For some reason, the specific setup of the machine was causing the issue.

The issue was that MSBuild would ignore precedence of AssemblySearchPaths, which places HintPath before {TargetFrameworkPath} when resolving the assemblies, and this resulted in the .NET 4.6 (the target framework of the generated project) assembly to be chosen over the explicitly referenced one of .NET 4.7.2 (what unity uses to compile).

The fix here is to remvoe {TargetFrameworkDirectory} from the search paths, and prevent the explicit addition of targetFramework dlls.