### PR TITLE
Enable interactive restore and ADO auth

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectBuilder.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectBuilder.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Build.Unity
         public const string RebuildTargetArgument = "-t:Rebuild";
         public const string DefaultBuildArguments = MSBuildProjectBuilder.BuildTargetArgument;
 
-        private const string adoAuthenticationUrl = "https://microsoft.com/devicelogin";
+        private const string AdoAuthenticationUrl = "https://microsoft.com/devicelogin";
+
         private static readonly Lazy<Task<string>> msBuildPathTask;
         private static readonly Regex msBuildErrorFormat = new Regex(@"^\s*(((?<ORIGIN>(((\d+>)?[a-zA-Z]?:[^:]*)|([^:]*))):)|())(?<SUBCATEGORY>(()|([^:]*? )))(?<CATEGORY>(error|warning))( \s*(?<CODE>[^: ]*))?\s*:(?<TEXT>.*)$", RegexOptions.Compiled);
-        private static readonly Regex adoAuthenticationFormat = new Regex($"\\s*(\\[CredentialProvider\\])?(?<Message>.*({MSBuildProjectBuilder.adoAuthenticationUrl}).*(?<Code>[A-Z|0-9]{{9}}).*)", RegexOptions.Compiled);
+        private static readonly Regex adoAuthenticationFormat = new Regex($"\\s*(\\[CredentialProvider\\])?(?<Message>.*({MSBuildProjectBuilder.AdoAuthenticationUrl}).*(?<Code>[A-Z|0-9]{{9}}).*)", RegexOptions.Compiled);
 
         private static bool isBuildingWithDefaultUI = false;
 
@@ -202,7 +203,7 @@ namespace Microsoft.Build.Unity
 
                             if (adoAuthenticationMatch?.Success == true)
                             {
-                                string message = $"{adoAuthenticationMatch.Groups["Message"].Value}{Environment.NewLine}{Environment.NewLine}Click OK to copy the authentication code to the clipboard and open {MSBuildProjectBuilder.adoAuthenticationUrl} in your default browser, or click Cancel to abort the build.";
+                                string message = $"{adoAuthenticationMatch.Groups["Message"].Value}{Environment.NewLine}{Environment.NewLine}Click OK to copy the authentication code to the clipboard and open {MSBuildProjectBuilder.AdoAuthenticationUrl} in your default browser, or click Cancel to abort the build.";
                                 string azureAuthenticationCode = adoAuthenticationMatch.Groups["Code"].Value;
 
                                 // Clear the match before asking the user the authenticate, since once this completes the build will continue and a new match can be made for an auth request on another feed.
@@ -214,7 +215,7 @@ namespace Microsoft.Build.Unity
                                     EditorGUIUtility.systemCopyBuffer = azureAuthenticationCode;
 
                                     // Launch the Azure DevOps device login web page
-                                    Application.OpenURL(MSBuildProjectBuilder.adoAuthenticationUrl);
+                                    Application.OpenURL(MSBuildProjectBuilder.AdoAuthenticationUrl);
                                 }
                                 else
                                 {

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectBuilder.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectBuilder.cs
@@ -27,8 +27,10 @@ namespace Microsoft.Build.Unity
         public const string RebuildTargetArgument = "-t:Rebuild";
         public const string DefaultBuildArguments = MSBuildProjectBuilder.BuildTargetArgument;
 
+        private const string adoAuthenticationUrl = "https://microsoft.com/devicelogin";
         private static readonly Lazy<Task<string>> msBuildPathTask;
         private static readonly Regex msBuildErrorFormat = new Regex(@"^\s*(((?<ORIGIN>(((\d+>)?[a-zA-Z]?:[^:]*)|([^:]*))):)|())(?<SUBCATEGORY>(()|([^:]*? )))(?<CATEGORY>(error|warning))( \s*(?<CODE>[^: ]*))?\s*:(?<TEXT>.*)$", RegexOptions.Compiled);
+        private static readonly Regex adoAuthenticationFormat = new Regex($"\\s*(\\[CredentialProvider\\])?(?<Message>.*({MSBuildProjectBuilder.adoAuthenticationUrl}).*(?<Code>[A-Z|0-9]{{9}}).*)", RegexOptions.Compiled);
 
         private static bool isBuildingWithDefaultUI = false;
 
@@ -155,20 +157,28 @@ namespace Microsoft.Build.Unity
                     {
                         int completedProjects = 0;
                         string progressMessage = string.Empty;
+                        Match adoAuthenticationMatch = null;
                         var cancellationTokenSource = new CancellationTokenSource();
 
                         DisplayProgress();
 
                         Task<bool> buildTask = MSBuildProjectBuilder.BuildProjectsAsync(
                             msBuildProjectReferences,
-                            $"{arguments} -v:minimal",
+                            $"{arguments} -v:minimal -p:NuGetInteractive=true",
                             new DelegateProgress<(int completedProjects, (string progressMessage, ProgressMessageType progressMessageType) progressUpdate)>(report =>
                             {
                                 if (report.progressUpdate.progressMessageType != ProgressMessageType.Information)
                                 {
                                     MSBuildProjectBuilder.LogProgressMessage(report.progressUpdate.progressMessage, report.progressUpdate.progressMessageType);
                                 }
+
                                 (completedProjects, progressMessage) = (report.completedProjects, report.progressUpdate.progressMessage);
+
+                                // Check whether the build is blocked on Azure DevOps package feed authentication
+                                if (MSBuildProjectBuilder.adoAuthenticationFormat.Match(progressMessage) is Match candidateAdoAuthenticationMatch && candidateAdoAuthenticationMatch.Success)
+                                {
+                                    adoAuthenticationMatch = candidateAdoAuthenticationMatch;
+                                }
                             }),
                             cancellationTokenSource.Token);
 
@@ -188,6 +198,27 @@ namespace Microsoft.Build.Unity
                             if (EditorUtility.DisplayCancelableProgressBar("Building MSBuild projects...", status, progress))
                             {
                                 cancellationTokenSource.Cancel();
+                            }
+
+                            if (adoAuthenticationMatch?.Success == true)
+                            {
+                                string message = $"{adoAuthenticationMatch.Groups["Message"].Value}{Environment.NewLine}{Environment.NewLine}Click OK to copy the authentication code to the clipboard and open {MSBuildProjectBuilder.adoAuthenticationUrl} in your default browser, or click Cancel to abort the build.";
+                                string azureAuthenticationCode = adoAuthenticationMatch.Groups["Code"].Value;
+
+                                if (EditorUtility.DisplayDialog("Azure DevOps Package Feed Authentication Required", message, "OK", "Cancel"))
+                                {
+                                    // Copy the authentication code to the clipboard for convenience
+                                    EditorGUIUtility.systemCopyBuffer = azureAuthenticationCode;
+
+                                    // Launch the Azure DevOps device login web page
+                                    Application.OpenURL(MSBuildProjectBuilder.adoAuthenticationUrl);
+                                }
+                                else
+                                {
+                                    cancellationTokenSource.Cancel();
+                                }
+
+                                adoAuthenticationMatch = null;
                             }
                         }
                     }


### PR DESCRIPTION
This change adds `-p:NuGetInteractive=true` to the build command, and scans for ADO package feed authentication requests. The ADO auth request is logged from the build, and this is detected via a regex, but most of the string is localized so the regex is a bit different than might be expected. It looks for the non-localized prefix of `[CredentialProvider]`, looks for the ADO auth url of `https://microsoft.com/devicelogin`, and looks for the 9 character auth code. A dialog is displayed that helps the user navigate to the auth page and enter the auth code.
![AdoAuth](https://user-images.githubusercontent.com/5084643/65062564-29d59980-d931-11e9-9cde-a0a20218f222.gif)
Clicking `OK` will take the user to a page that looks like this:
![image](https://user-images.githubusercontent.com/5084643/65062689-67d2bd80-d931-11e9-87ce-b104f7628260.png)
After entering the code and clicking `Next`, the authentication will be completed and NuGet restore will complete and the build will continue.

This is arguably fragile because if the ADO NuGet auth plugin is updated and changes the format of the output, this could break. It would be more robust to just show the build output as multi-line selectable text and just let the user observe the auth request in the build output (same as would happen when building on the command line), but this actually requires a lot more code. Since the solution I have here is a small amount of code and yields a better workflow, I thought I'd start with this solution.

This addresses issue #4.