### PR TITLE
Move AutoBuild flag to each Profile

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildBuildProfile.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildBuildProfile.cs
@@ -7,15 +7,23 @@ namespace Microsoft.Build.Unity
     public sealed class MSBuildBuildProfile
     {
         [SerializeField]
+        [Tooltip("The name of the profile.")]
         private string name = null;
 
         [SerializeField]
+        [Tooltip("Indicates whether the referenced MSBuild project should automatically be built.")]
+        private bool autoBuild = false;
+
+        [SerializeField]
+        [Tooltip("The arguments passed to MSBuild when building the project with this profile.")]
         private string arguments = null;
 
         public string Name => this.name;
 
+        public bool AutoBuild => this.autoBuild;
+
         public string Arguments => this.arguments;
 
-        public static MSBuildBuildProfile Create(string name, string arguments) => new MSBuildBuildProfile { name = name, arguments = arguments };
+        public static MSBuildBuildProfile Create(string name, bool autoBuild, string arguments) => new MSBuildBuildProfile { name = name, autoBuild = autoBuild, arguments = arguments };
     }
 }

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectBuilderEditor.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectBuilderEditor.cs
@@ -89,8 +89,16 @@ namespace Microsoft.Build.Unity
             //[MenuItem("MSBuild/Auto Build All Projects [testing only]", priority = int.MaxValue)]
             private static void BuildAllAutoBuiltProjects()
             {
-                (IEnumerable<MSBuildProjectReference> withProfile, _) = MSBuildProjectBuilder.SplitByProfile(MSBuildProjectBuilder.EnumerateAllMSBuildProjectReferences(), "Build");
-                MSBuildProjectBuilder.BuildProjects(withProfile.Where(projectReference => projectReference.AutoBuild).ToArray(), "Build");
+                IEnumerable<IGrouping<string, MSBuildProjectReference>> autoBuildProfiles =
+                    from projectReference in MSBuildProjectBuilder.EnumerateAllMSBuildProjectReferences()
+                    from profile in projectReference.Profiles
+                    where profile.autoBuild
+                    group projectReference by profile.name;
+
+                foreach (IGrouping<string, MSBuildProjectReference> autoBuildProfile in autoBuildProfiles)
+                {
+                    MSBuildProjectBuilder.BuildProjects(autoBuildProfile.ToArray(), autoBuildProfile.Key);
+                }
             }
         }
     }

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectImporter.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectImporter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using UnityEditor;
 using UnityEditor.Experimental.AssetImporters;
 using UnityEngine;
@@ -26,15 +27,18 @@ namespace Microsoft.Build.Unity
 
             // Automatically build this project if the import is happening after the Unity project has been opened.
             // If the import is happening as part of loading the project, then the generated asset will automatically be built by MSBuildProjectBuilder.
-            if (EditorAnalyticsSessionInfo.elapsedTime != 0)
+            if (EditorAnalyticsSessionInfo.elapsedTime != 0 && msBuildProjectReference.Profiles != null)
             {
-                try
+                foreach (var profile in msBuildProjectReference.Profiles.Where(profile => profile.autoBuild))
                 {
-                    msBuildProjectReference.BuildProject("Build");
-                }
-                catch (OperationCanceledException)
-                {
-                    Debug.LogWarning($"Canceled building {msBuildProjectReference.ProjectPath}.");
+                    try
+                    {
+                        msBuildProjectReference.BuildProject(profile.name);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        Debug.LogWarning($"Canceled building {msBuildProjectReference.ProjectPath}.");
+                    }
                 }
             }
         }

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectReference.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectReference.cs
@@ -26,15 +26,11 @@ namespace Microsoft.Build.Unity
         private BuildEngine buildEngine = BuildEngine.DotNet;
 
         [SerializeField]
-        [Tooltip("Indicates whether the referenced MSBuild project should automatically be built.")]
-        private bool autoBuild = true;
-
-        [SerializeField]
         [Tooltip("Named profiles to configure different build options.")]
         private MSBuildBuildProfile[] profiles = new[]
         {
-            MSBuildBuildProfile.Create("Build", "-t:Build -p:Configuration=Release"),
-            MSBuildBuildProfile.Create("Rebuild", "-t:Rebuild -p:Configuration=Release"),
+            MSBuildBuildProfile.Create(name: "Build", autoBuild: true, arguments: "-t:Build -p:Configuration=Release"),
+            MSBuildBuildProfile.Create(name: "Rebuild", autoBuild: false, arguments: "-t:Rebuild -p:Configuration=Release"),
         };
 
         /// <summary>
@@ -54,7 +50,6 @@ namespace Microsoft.Build.Unity
             msBuildProjectReference.assetRelativePath = assetRelativePath;
             msBuildProjectReference.projectPath = Path.GetFileName(assetRelativePath);
             msBuildProjectReference.buildEngine = buildEngine;
-            msBuildProjectReference.autoBuild = autoBuild;
 
             if (profiles != null && profiles.Any())
             {
@@ -91,8 +86,6 @@ namespace Microsoft.Build.Unity
 
         public BuildEngine BuildEngine => this.buildEngine;
 
-        public bool AutoBuild => this.autoBuild;
-
-        public IEnumerable<(string name, string arguments)> Profiles => this.profiles == null ? Enumerable.Empty<(string, string)>() : this.profiles.Select(profile => (profile.Name, profile.Arguments));
+        public IEnumerable<(string name, bool autoBuild, string arguments)> Profiles => this.profiles == null ? Enumerable.Empty<(string, bool, string)>() : this.profiles.Select(profile => (profile.Name, profile.AutoBuild, profile.Arguments));
     }
 }


### PR DESCRIPTION
This change moves the `AutoBuild` flag from the `MSBuildProjectReference` to the individual `MSBuildBuildProfile`s that are on the `MSBuildProjectReference`. This makes a lot more sense than just trying to guess which "profile" to auto build across all referenced projects. By default, `MSBuildProjectReference`s are created with a `Build` profile with `AutoBuild` set to `true`, so the default behavior is not changing, it just makes more sense now and is more configurable.