### PR TITLE
Sign dlls and package

### DIFF
--- a/AzurePipelines/PRGate.yml
+++ b/AzurePipelines/PRGate.yml
@@ -16,5 +16,6 @@ workspace:
 steps:
 - template: Templates/CommonInitialization.yml
 - template: Templates/BuildMSBuildForUnityNuGetBinaries.yml
+- template: Templates/BuildMSBuildForUnityNuGetPackage.yml
 # Commenting out the ability to publish the NuGet packages until we get approval from legal
 #- template: Templates/PublishArtifacts.yml

--- a/AzurePipelines/PRGate.yml
+++ b/AzurePipelines/PRGate.yml
@@ -15,6 +15,6 @@ workspace:
 
 steps:
 - template: Templates/CommonInitialization.yml
-- template: Templates/BuildMSBuildForUnityNuget.yml
+- template: Templates/BuildMSBuildForUnityNuGetBinaries.yml
 # Commenting out the ability to publish the NuGet packages until we get approval from legal
 #- template: Templates/PublishArtifacts.yml

--- a/AzurePipelines/Publish.NuGet.yml
+++ b/AzurePipelines/Publish.NuGet.yml
@@ -21,28 +21,5 @@ workspace:
 steps:
 - template: Templates/CommonInitialization.yml
 - template: Templates/BuildMSBuildForUnityNuget.yml
-- task: EsrpCodeSigning@1
-  inputs:
-    ConnectedServiceName: 'ESRP Code Signing'
-    FolderPath: '$(System.DefaultWorkingDirectory)\Source\MSBuildTools.Unity.Nuget\bin\Release'
-    Pattern: 'MSBuildForUnity.*.nupkg'
-    signConfigType: 'inlineSignParams'
-    inlineOperation: |
-      [
-        {
-          "KeyCode" : "CP-401405",
-          "OperationCode" : "NuGetSign",
-          "Parameters" : {},
-          "ToolName" : "sign",
-          "ToolVersion" : "1.0"
-        },
-        {
-          "KeyCode" : "CP-401405",
-          "OperationCode" : "NuGetVerify",
-          "Parameters" : {},
-          "ToolName" : "sign",
-          "ToolVersion" : "1.0"
-        }
-      ]
 - template: Templates/PublishArtifacts.yml
-#- template: Templates/PublishNuGetPackages.yml
+- template: Templates/PublishNuGetPackages.yml

--- a/AzurePipelines/Publish.NuGet.yml
+++ b/AzurePipelines/Publish.NuGet.yml
@@ -21,6 +21,28 @@ workspace:
 steps:
 - template: Templates/CommonInitialization.yml
 - template: Templates/BuildMSBuildForUnityNuget.yml
-
+- task: EsrpCodeSigning@1
+  inputs:
+    ConnectedServiceName: 'ESRP Code Signing'
+    FolderPath: '$(System.DefaultWorkingDirectory)\Source\MSBuildTools.Unity.Nuget\bin\Release'
+    Pattern: 'MSBuildForUnity.*.nupkg'
+    signConfigType: 'inlineSignParams'
+    inlineOperation: |
+      [
+        {
+          "KeyCode" : "CP-401405",
+          "OperationCode" : "NuGetSign",
+          "Parameters" : {},
+          "ToolName" : "sign",
+          "ToolVersion" : "1.0"
+        },
+        {
+          "KeyCode" : "CP-401405",
+          "OperationCode" : "NuGetVerify",
+          "Parameters" : {},
+          "ToolName" : "sign",
+          "ToolVersion" : "1.0"
+        }
+      ]
 - template: Templates/PublishArtifacts.yml
 #- template: Templates/PublishNuGetPackages.yml

--- a/AzurePipelines/Publish.NuGet.yml
+++ b/AzurePipelines/Publish.NuGet.yml
@@ -21,5 +21,6 @@ workspace:
 steps:
 - template: Templates/CommonInitialization.yml
 - template: Templates/BuildMSBuildForUnityNuget.yml
+- template: Templates/SignNuGetPackages.yml
 - template: Templates/PublishArtifacts.yml
 - template: Templates/PublishNuGetPackages.yml

--- a/AzurePipelines/Publish.NuGet.yml
+++ b/AzurePipelines/Publish.NuGet.yml
@@ -21,6 +21,7 @@ workspace:
 steps:
 - template: Templates/CommonInitialization.yml
 - template: Templates/BuildMSBuildForUnityNuGetBinaries.yml
+- template: Templates/SignBinaries.yml
 - template: Templates/BuildMSBuildForUnityNuGetPackage.yml
 - template: Templates/SignNuGetPackages.yml
 - template: Templates/PublishArtifacts.yml

--- a/AzurePipelines/Publish.NuGet.yml
+++ b/AzurePipelines/Publish.NuGet.yml
@@ -20,7 +20,8 @@ workspace:
 
 steps:
 - template: Templates/CommonInitialization.yml
-- template: Templates/BuildMSBuildForUnityNuget.yml
+- template: Templates/BuildMSBuildForUnityNuGetBinaries.yml
+- template: Templates/BuildMSBuildForUnityNuGetPackage.yml
 - template: Templates/SignNuGetPackages.yml
 - template: Templates/PublishArtifacts.yml
 - template: Templates/PublishNuGetPackages.yml

--- a/AzurePipelines/Publish.NuGet.yml
+++ b/AzurePipelines/Publish.NuGet.yml
@@ -21,6 +21,6 @@ workspace:
 steps:
 - template: Templates/CommonInitialization.yml
 - template: Templates/BuildMSBuildForUnityNuget.yml
-# Commenting out the ability to publish the NuGet packages until we get approval from legal
-#- template: Templates/PublishArtifacts.yml
-- template: Templates/PublishNuGetPackages.yml
+
+- template: Templates/PublishArtifacts.yml
+#- template: Templates/PublishNuGetPackages.yml

--- a/AzurePipelines/Templates/BuildMSBuildForUnityNuGetBinaries.yml
+++ b/AzurePipelines/Templates/BuildMSBuildForUnityNuGetBinaries.yml
@@ -4,4 +4,4 @@ steps:
   inputs:
     solution: 'Source\MSBuildTools.Unity.Nuget\MSBuildForUnity.NuGet.sln'
     configuration: Release
-    msbuildArguments: '/restore /bl:$(Build.SourcesDirectory)\MSBuildForUnity.NuGet.binlog'
+    msbuildArguments: '/p:GeneratePackageOnBuild=false /restore /bl:$(Build.SourcesDirectory)\MSBuildForUnity.Source.binlog'

--- a/AzurePipelines/Templates/BuildMSBuildForUnityNuGetPackage.yml
+++ b/AzurePipelines/Templates/BuildMSBuildForUnityNuGetPackage.yml
@@ -1,0 +1,7 @@
+steps:
+- task: MSBuild@1
+  displayName: "Package Solution"
+  inputs:
+    solution: 'Source\MSBuildTools.Unity.Nuget\MSBuildForUnity.NuGet.sln'
+    configuration: Release
+    msbuildArguments: '/t:Pack /p:NoBuild=true /bl:$(Build.SourcesDirectory)\MSBuildForUnity.NuGet.binlog'

--- a/AzurePipelines/Templates/PublishNuGetPackages.yml
+++ b/AzurePipelines/Templates/PublishNuGetPackages.yml
@@ -1,28 +1,4 @@
 steps:
-- task: EsrpCodeSigning@1
-  displayName: Sign NuGet Package
-  inputs:
-    ConnectedServiceName: 'ESRP Code Signing'
-    FolderPath: '$(System.DefaultWorkingDirectory)\Source\MSBuildTools.Unity.Nuget\bin\Release'
-    Pattern: 'MSBuildForUnity.*.nupkg'
-    signConfigType: 'inlineSignParams'
-    inlineOperation: |
-      [
-        {
-          "KeyCode" : "CP-401405",
-          "OperationCode" : "NuGetSign",
-          "Parameters" : {},
-          "ToolName" : "sign",
-          "ToolVersion" : "1.0"
-        },
-        {
-          "KeyCode" : "CP-401405",
-          "OperationCode" : "NuGetVerify",
-          "Parameters" : {},
-          "ToolName" : "sign",
-          "ToolVersion" : "1.0"
-        }
-      ]
 - task: NuGetCommand@2
   displayName: Publish NuGet Package
   inputs:

--- a/AzurePipelines/Templates/PublishNuGetPackages.yml
+++ b/AzurePipelines/Templates/PublishNuGetPackages.yml
@@ -4,6 +4,5 @@ steps:
   inputs:
     command: 'push'
     packagesToPush: '$(Build.SourcesDirectory)/Source/MSBuildTools.Unity.Nuget/bin/Release/MSBuildForUnity.*.nupkg;!$(Build.SourcesDirectory)/**/bin/**/*.symbols.nupkg'
-    # Publish only to the secure internal feed until we get approval from legal
-    nuGetFeedType: 'internal'
-    publishVstsFeed: 'c5734843-0320-4d3d-8a13-9f75d441dd1c'
+    nuGetFeedType: 'external'
+    publishFeedCredentials: 'Unity Developer Tools'

--- a/AzurePipelines/Templates/PublishNuGetPackages.yml
+++ b/AzurePipelines/Templates/PublishNuGetPackages.yml
@@ -29,5 +29,4 @@ steps:
     command: 'push'
     packagesToPush: '$(Build.SourcesDirectory)/**/bin/**/*.nupkg;!$(Build.SourcesDirectory)/**/bin/**/*.symbols.nupkg'
     # Publish only to the secure internal feed until we get approval from legal
-    nuGetFeedType: 'external'
-    publishFeedCredentials: 'MRW.Shared NuGet Credentials'
+    nuGetFeedType: 'internal'

--- a/AzurePipelines/Templates/PublishNuGetPackages.yml
+++ b/AzurePipelines/Templates/PublishNuGetPackages.yml
@@ -30,3 +30,4 @@ steps:
     packagesToPush: '$(Build.SourcesDirectory)/**/bin/**/*.nupkg;!$(Build.SourcesDirectory)/**/bin/**/*.symbols.nupkg'
     # Publish only to the secure internal feed until we get approval from legal
     nuGetFeedType: 'internal'
+    publishVstsFeed: 'c5734843-0320-4d3d-8a13-9f75d441dd1c'

--- a/AzurePipelines/Templates/PublishNuGetPackages.yml
+++ b/AzurePipelines/Templates/PublishNuGetPackages.yml
@@ -3,7 +3,7 @@ steps:
   displayName: Publish NuGet Package
   inputs:
     command: 'push'
-    packagesToPush: '$(Build.SourcesDirectory)/**/bin/**/*.nupkg;!$(Build.SourcesDirectory)/**/bin/**/*.symbols.nupkg'
+    packagesToPush: '$(Build.SourcesDirectory)/Source/MSBuildTools.Unity.Nuget/bin/Release/MSBuildForUnity.*.nupkg;!$(Build.SourcesDirectory)/**/bin/**/*.symbols.nupkg'
     # Publish only to the secure internal feed until we get approval from legal
     nuGetFeedType: 'internal'
     publishVstsFeed: 'c5734843-0320-4d3d-8a13-9f75d441dd1c'

--- a/AzurePipelines/Templates/PublishNuGetPackages.yml
+++ b/AzurePipelines/Templates/PublishNuGetPackages.yml
@@ -1,4 +1,28 @@
 steps:
+- task: EsrpCodeSigning@1
+  displayName: Sign NuGet Package
+  inputs:
+    ConnectedServiceName: 'ESRP Code Signing'
+    FolderPath: '$(System.DefaultWorkingDirectory)\Source\MSBuildTools.Unity.Nuget\bin\Release'
+    Pattern: 'MSBuildForUnity.*.nupkg'
+    signConfigType: 'inlineSignParams'
+    inlineOperation: |
+      [
+        {
+          "KeyCode" : "CP-401405",
+          "OperationCode" : "NuGetSign",
+          "Parameters" : {},
+          "ToolName" : "sign",
+          "ToolVersion" : "1.0"
+        },
+        {
+          "KeyCode" : "CP-401405",
+          "OperationCode" : "NuGetVerify",
+          "Parameters" : {},
+          "ToolName" : "sign",
+          "ToolVersion" : "1.0"
+        }
+      ]
 - task: NuGetCommand@2
   displayName: Publish NuGet Package
   inputs:

--- a/AzurePipelines/Templates/SignBinaries.yml
+++ b/AzurePipelines/Templates/SignBinaries.yml
@@ -1,0 +1,31 @@
+steps:
+- task: EsrpCodeSigning@1
+  displayName: Sign NuGet Package
+  inputs:
+    ConnectedServiceName: 'ESRP Code Signing'
+    FolderPath: '$(Build.SourcesDirectory)/Source/MSBuildTools.Unity.Nuget/bin/Release'
+    Pattern: 'MSBuildForUnity.dll'
+    signConfigType: 'inlineSignParams'
+    inlineOperation: |
+      [
+        {
+            "KeyCode" : "CP-230012",
+            "OperationCode" : "SigntoolSign",
+            "Parameters" : {
+                "OpusName" : "Microsoft",
+                "OpusInfo" : "http://www.microsoft.com",
+                "FileDigest" : "/fd \"SHA256\"",
+                "PageHash" : "/NPH",
+                "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            },
+            "ToolName" : "sign",
+            "ToolVersion" : "1.0"
+        },
+        {
+            "KeyCode" : "CP-230012",
+            "OperationCode" : "SigntoolVerify",
+            "Parameters" : {},
+            "ToolName" : "sign",
+            "ToolVersion" : "1.0"
+        }
+      ]

--- a/AzurePipelines/Templates/SignBinaries.yml
+++ b/AzurePipelines/Templates/SignBinaries.yml
@@ -1,6 +1,6 @@
 steps:
 - task: EsrpCodeSigning@1
-  displayName: Sign NuGet Package
+  displayName: Sign Binaries
   inputs:
     ConnectedServiceName: 'ESRP Code Signing'
     FolderPath: '$(Build.SourcesDirectory)/Source/MSBuildTools.Unity.Nuget/bin/Release'

--- a/AzurePipelines/Templates/SignNuGetPackages.yml
+++ b/AzurePipelines/Templates/SignNuGetPackages.yml
@@ -1,0 +1,25 @@
+steps:
+- task: EsrpCodeSigning@1
+  displayName: Sign NuGet Package
+  inputs:
+    ConnectedServiceName: 'ESRP Code Signing'
+    FolderPath: '$(System.DefaultWorkingDirectory)\Source\MSBuildTools.Unity.Nuget\bin\Release'
+    Pattern: 'MSBuildForUnity.*.nupkg'
+    signConfigType: 'inlineSignParams'
+    inlineOperation: |
+      [
+        {
+          "KeyCode" : "CP-401405",
+          "OperationCode" : "NuGetSign",
+          "Parameters" : {},
+          "ToolName" : "sign",
+          "ToolVersion" : "1.0"
+        },
+        {
+          "KeyCode" : "CP-401405",
+          "OperationCode" : "NuGetVerify",
+          "Parameters" : {},
+          "ToolName" : "sign",
+          "ToolVersion" : "1.0"
+        }
+      ]

--- a/AzurePipelines/Templates/SignNuGetPackages.yml
+++ b/AzurePipelines/Templates/SignNuGetPackages.yml
@@ -3,7 +3,7 @@ steps:
   displayName: Sign NuGet Package
   inputs:
     ConnectedServiceName: 'ESRP Code Signing'
-    FolderPath: '$(System.DefaultWorkingDirectory)\Source\MSBuildTools.Unity.Nuget\bin\Release'
+    FolderPath: '$(Build.SourcesDirectory)/Source/MSBuildTools.Unity.Nuget/bin/Release'
     Pattern: 'MSBuildForUnity.*.nupkg'
     signConfigType: 'inlineSignParams'
     inlineOperation: |


### PR DESCRIPTION
This change updates the NuGet package build to sign MSBuildForUnity.dll as well as the NuGet package itself.
- Break the existing build step into two separate steps (build and package)
- Add a step for signing binaries between building and packaging
- Add a step for signing the package