### PR TITLE
Sign third party components

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Source/Mono.Cecil"]
-	path = Source/Mono.Cecil
-	url = https://github.com/jbevain/cecil.git

--- a/AzurePipelines/Publish.NuGet.yml
+++ b/AzurePipelines/Publish.NuGet.yml
@@ -25,4 +25,4 @@ steps:
 - template: Templates/BuildMSBuildForUnityNuGetPackage.yml
 - template: Templates/SignNuGetPackages.yml
 - template: Templates/PublishArtifacts.yml
-- template: Templates/PublishNuGetPackages.yml
+#- template: Templates/PublishNuGetPackages.yml

--- a/AzurePipelines/Publish.NuGet.yml
+++ b/AzurePipelines/Publish.NuGet.yml
@@ -26,6 +26,7 @@ steps:
 - template: Templates/SignNuGetPackages.yml
 - template: Templates/PublishArtifacts.yml
 - task: ComponentGovernanceComponentDetection@0
+  displayName: "Scan Third Party Components"
   inputs:
     scanType: 'LogOnly'
     verbosity: 'Verbose'

--- a/AzurePipelines/Publish.NuGet.yml
+++ b/AzurePipelines/Publish.NuGet.yml
@@ -25,4 +25,10 @@ steps:
 - template: Templates/BuildMSBuildForUnityNuGetPackage.yml
 - template: Templates/SignNuGetPackages.yml
 - template: Templates/PublishArtifacts.yml
+- task: ComponentGovernanceComponentDetection@0
+  inputs:
+    scanType: 'LogOnly'
+    verbosity: 'Verbose'
+    alertWarningLevel: 'High'
+    failOnAlert: true
 #- template: Templates/PublishNuGetPackages.yml

--- a/AzurePipelines/Publish.NuGet.yml
+++ b/AzurePipelines/Publish.NuGet.yml
@@ -32,4 +32,4 @@ steps:
     verbosity: 'Verbose'
     alertWarningLevel: 'High'
     failOnAlert: true
-#- template: Templates/PublishNuGetPackages.yml
+- template: Templates/PublishNuGetPackages.yml

--- a/AzurePipelines/Publish.NuGet.yml
+++ b/AzurePipelines/Publish.NuGet.yml
@@ -28,8 +28,8 @@ steps:
 - task: ComponentGovernanceComponentDetection@0
   displayName: "Scan Third Party Components"
   inputs:
-    scanType: 'LogOnly'
+    scanType: 'Register'
     verbosity: 'Verbose'
     alertWarningLevel: 'High'
     failOnAlert: true
-- template: Templates/PublishNuGetPackages.yml
+#- template: Templates/PublishNuGetPackages.yml

--- a/AzurePipelines/Templates/SignBinaries.yml
+++ b/AzurePipelines/Templates/SignBinaries.yml
@@ -1,6 +1,6 @@
 steps:
 - task: EsrpCodeSigning@1
-  displayName: Sign Binaries
+  displayName: Sign First Party Binaries
   inputs:
     ConnectedServiceName: 'ESRP Code Signing'
     FolderPath: '$(Build.SourcesDirectory)/Source/MSBuildTools.Unity.Nuget/bin/Release'
@@ -23,6 +23,40 @@ steps:
         },
         {
             "KeyCode" : "CP-230012",
+            "OperationCode" : "SigntoolVerify",
+            "Parameters" : {},
+            "ToolName" : "sign",
+            "ToolVersion" : "1.0"
+        }
+      ]
+- task: EsrpCodeSigning@1
+  displayName: Sign Third Party Binaries
+  inputs:
+    ConnectedServiceName: 'ESRP Code Signing'
+    FolderPath: '$(Build.SourcesDirectory)/Source/MSBuildTools.Unity.Nuget/bin/Release'
+    Pattern: |
+      Mono.Cecil.dll,
+      Mono.Cecil.*.dll,
+      Newtonsoft.Json.dll,
+    signConfigType: 'inlineSignParams'
+    inlineOperation: |
+      [
+        {
+            "KeyCode" : "CP-231522",
+            "OperationCode" : "SigntoolSign",
+            "Parameters" : {
+                "OpusName" : "Microsoft",
+                "OpusInfo" : "http://www.microsoft.com",
+                "Append" : "/as",
+                "FileDigest" : "/fd \"SHA256\"",
+                "PageHash" : "/NPH",
+                "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            },
+            "ToolName" : "sign",
+            "ToolVersion" : "1.0"
+        },
+        {
+            "KeyCode" : "CP-231522",
             "OperationCode" : "SigntoolVerify",
             "Parameters" : {},
             "ToolName" : "sign",

--- a/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.NuGet.sln
+++ b/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.NuGet.sln
@@ -5,10 +5,6 @@ VisualStudioVersion = 16.0.29306.81
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSBuildForUnity", "MSBuildForUnity.csproj", "{1FA0918F-59B8-4935-9CB9-E4A5459B3646}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mono.Cecil", "..\Mono.Cecil\Mono.Cecil.csproj", "{344743DE-3899-4B2A-B57F-BC30560BA4FA}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mono.Cecil.Pdb", "..\Mono.Cecil\symbols\pdb\Mono.Cecil.Pdb.csproj", "{DA8E10E4-B8B2-4E6A-8388-C21F1D3E8900}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -19,14 +15,6 @@ Global
 		{1FA0918F-59B8-4935-9CB9-E4A5459B3646}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1FA0918F-59B8-4935-9CB9-E4A5459B3646}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1FA0918F-59B8-4935-9CB9-E4A5459B3646}.Release|Any CPU.Build.0 = Release|Any CPU
-		{344743DE-3899-4B2A-B57F-BC30560BA4FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{344743DE-3899-4B2A-B57F-BC30560BA4FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{344743DE-3899-4B2A-B57F-BC30560BA4FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{344743DE-3899-4B2A-B57F-BC30560BA4FA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DA8E10E4-B8B2-4E6A-8388-C21F1D3E8900}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DA8E10E4-B8B2-4E6A-8388-C21F1D3E8900}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DA8E10E4-B8B2-4E6A-8388-C21F1D3E8900}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DA8E10E4-B8B2-4E6A-8388-C21F1D3E8900}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
+++ b/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
@@ -17,6 +17,9 @@
 
     <!-- Don't warn about DLL's outside of the lib folder, the DLL is for the MSBuild task so it should NOT live in the lib folder -->
     <NoWarn>$(NoWarn);NU5100</NoWarn>
+
+    <!-- Dependencies need to be copied to the output directory so they can be signed -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <!-- Setup the versioning for the package based on the build number if provided -->
@@ -26,9 +29,7 @@
 
     <MinorVersion>1</MinorVersion>
 
-    <!--
-      Minor is defaulted to 0, but if running in the lab where BuildID is specified then default the revision to that value.
-    -->
+    <!-- Revision is defaulted to 0, but if running in the lab where BuildID is specified then default the revision to that value. -->
     <RevisionVersion>0</RevisionVersion>
     <RevisionVersion Condition="'$(BUILD_BUILDID)' != ''">$(BUILD_BUILDID)</RevisionVersion>
 

--- a/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
+++ b/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
@@ -1,4 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
+
+  <Import Project="SDK.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -65,10 +67,17 @@
       There is a runtime dependency on Mono.Cecil and Newtonsoft for the tasks. Unfortunately there is no way to express that as a NuGet package dependency for build tasks.
       The only real option is to bundle the Mono.Cecil DLL's into our own package.
     -->
-  <Target Name="EmbedMonoCecil" AfterTargets="ResolveReferences">
+  <Target Name="EmbedMonoCecil" DependsOnTargets="ResolveReferences">
     <ItemGroup>
       <Content Include="@(ReferencePath)" Condition="$([System.String]::new('%(ReferencePath.Filename)').StartsWith('Mono.Cecil'))" PackagePath="buildCommon" />
       <Content Include="@(ReferencePath)" Condition="$([System.String]::new('%(ReferencePath.Filename)').StartsWith('Newtonsoft'))" PackagePath="buildCommon" />
     </ItemGroup>
   </Target>
+
+  <Import Project="SDK.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <PackDependsOn>EmbedMonoCecil;$(PackDependsOn)</PackDependsOn>
+  </PropertyGroup>
+
 </Project>

--- a/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
+++ b/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
@@ -56,12 +56,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Mono.Cecil\Mono.Cecil.csproj" />
-    <ProjectReference Include="..\Mono.Cecil\symbols\pdb\Mono.Cecil.Pdb.csproj" />
   </ItemGroup>
 
   <!--

--- a/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
+++ b/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
@@ -68,10 +68,11 @@
       There is a runtime dependency on Mono.Cecil and Newtonsoft for the tasks. Unfortunately there is no way to express that as a NuGet package dependency for build tasks.
       The only real option is to bundle the Mono.Cecil DLL's into our own package.
     -->
-  <Target Name="EmbedMonoCecil" DependsOnTargets="ResolveReferences">
-    <ItemGroup>
-      <Content Include="@(ReferencePath)" Condition="$([System.String]::new('%(ReferencePath.Filename)').StartsWith('Mono.Cecil'))" PackagePath="buildCommon" />
-      <Content Include="@(ReferencePath)" Condition="$([System.String]::new('%(ReferencePath.Filename)').StartsWith('Newtonsoft'))" PackagePath="buildCommon" />
+  <Target Name="EmbedMonoCecil">
+     <ItemGroup>
+      <Content Include="$(OutputPath)\Mono.Cecil.dll" PackagePath="buildCommon" />
+      <Content Include="$(OutputPath)\Mono.Cecil.*.dll" PackagePath="buildCommon" />
+      <Content Include="$(OutputPath)\Newtonsoft.Json.dll" PackagePath="buildCommon" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
The primary change here is to sign third party components (Newtonsoft.Json and Mono.Cecil) and include them in the NuGet package:
- Update MSBuildForUnity.csproj to ensure third party components are copied to the output directory (so we can sign them), and make sure they are then packaged up with the NuGet package.
- Update the code signing steps to sign the third party components.

I also made a couple related changes::
- Replace the Mono.Cecil submodule with the actual NuGet package (an updated package was published a few days ago with the bug fixes we needed).
- Add the ComponentGovernanceComponentDetection step to check for third party components with any known problems (we shouldn't ship such components).