### PR TITLE
Move GenerateAssetId into a custom C# task

### DIFF
--- a/Source/MSBuildTools.Unity.NuGet/Tasks/GenerateAssetId.cs
+++ b/Source/MSBuildTools.Unity.NuGet/Tasks/GenerateAssetId.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MSBuildForUnity.Tasks
+{
+    /// <summary>
+    /// Generates a Unity asset id (formatted guid) from an asset name (text).
+    /// Since Unity asset ids are guids(128 bit), use an MD5 hash (also 128 bits) formatted as a hex string.
+    /// </summary>
+    public sealed class GenerateAssetId : Task
+    {
+        [Required]
+        public string AssetName { get; set; }
+
+        [Output]
+        public String AssetId { get; set; }
+
+        public override bool Execute()
+        {
+            byte[] inputBytes = Encoding.UTF8.GetBytes(this.AssetName);
+            using (var md5 = MD5.Create())
+            {
+                byte[] hashBytes = md5.ComputeHash(inputBytes);
+                this.AssetId = string.Join(string.Empty, hashBytes.Select(b => b.ToString("x2")));
+            }
+
+            return true;
+        }
+    }
+}

--- a/Source/MSBuildTools.Unity.NuGet/UnityMetaFileGenerator.props
+++ b/Source/MSBuildTools.Unity.NuGet/UnityMetaFileGenerator.props
@@ -4,6 +4,8 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+  <UsingTask TaskName="GenerateAssetId" AssemblyFile="$(MSBuildThisFileDirectory)MSBuildForUnity.dll" />
+
   <!-- These are the extensions that should have associated .meta files. -->
   <ItemGroup>
     <UnityPluginFileExtensions Include="dll;winmd" />

--- a/Source/MSBuildTools.Unity.NuGet/UnityMetaFileGenerator.targets
+++ b/Source/MSBuildTools.Unity.NuGet/UnityMetaFileGenerator.targets
@@ -173,28 +173,4 @@ PluginImporter:
     </ItemGroup>
   </Target>
 
-  <!--Generates a Unity asset id (formatted guid) from an asset name (text).
-      Since Unity asset ids are guids (128 bit), use an MD5 hash (also 128 bits) formatted as a hex string. -->
-  <UsingTask TaskName="GenerateAssetId" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <AssetName ParameterType="System.String" Required="true" />
-      <AssetId ParameterType="System.String" Output="true" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System.Linq" />
-      <Using Namespace="System.Security.Cryptography" />
-      <Using Namespace="System.Text" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-            byte[] inputBytes = Encoding.UTF8.GetBytes(this.AssetName);
-            using (var md5 = MD5.Create())
-            {
-                byte[] hashBytes = md5.ComputeHash(inputBytes);
-                this.AssetId = string.Join(string.Empty, hashBytes.Select(b => b.ToString("x2")));
-            }
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
 </Project>


### PR DESCRIPTION
CodeTaskFactory is not compatible with dotnet. Moving this into the existing dll as a custom C# based task solves this.