### PR TITLE
Updating Readme, plus version range

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ MSBuildForUnity solves the problem of establishing clear dependency relationship
 
 The samples included in this repository best convey the simplicity and value of this component:
 
-- [Simple NuGet Dependency Sample](Samples/SimpleNuGetDependency.Unity/Readme.md) - Showcases the simplest and most minimal usage of this component to pull in a dependency.
-- [Integrated Dependencies Sample](Samples/IntegratedDependencies.Unity/Readme.md) - Showcases the power of this component by relying on project generation.
+- [Simple NuGet Dependency Sample](Samples/SimpleNuGetDependency.Unity/README.md) - Showcases the simplest and most minimal usage of this component to pull in a dependency.
+- [Integrated Dependencies Sample](Samples/IntegratedDependencies.Unity/README.md) - Showcases the power of this component by relying on project generation.
 
 ## Contributing
 

--- a/Samples/SimpleNuGetDependency.Unity/Assets/NewtonsoftDependency/NewtonsoftDependency.csproj
+++ b/Samples/SimpleNuGetDependency.Unity/Assets/NewtonsoftDependency/NewtonsoftDependency.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MSBuildForUnity" Version="0.1.*">
+    <PackageReference Include="MSBuildForUnity" Version="[0.8.0-*, 0.8.0]">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/DependenciesProjectTemplate.g.props.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/DependenciesProjectTemplate.g.props.template
@@ -20,7 +20,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MSBuildForUnity" Version="[0.1.117077,)">
+    <PackageReference Include="MSBuildForUnity" Version="[0.8.0-*, 0.8.0]">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
There are two changes here:
- Updating MSBuildForUnity NuGet package reference that is either generated or embedded in the simple sample. The new version range allows any 0.8.0- prerelease, or a 0.8.0 package as max.
- Correcting casing on main readme links