### PR TITLE
Increment NPM Version only on Master

### DIFF
--- a/AzurePipelines/Publish.UPM.yml
+++ b/AzurePipelines/Publish.UPM.yml
@@ -15,6 +15,8 @@ pool:
 
 steps:
 - task: Npm@1
+# Only update the version on master branch
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master') 
   inputs:
     command: 'custom'
     customCommand: --no-git-tag-version version prerelease --preid=$(Build.BuildNumber)


### PR DESCRIPTION
I would like to use the same NPM pipeline to build and push release package, for that I want to increment the versions only on master branches.