### PR TITLE
Final Prep for Release

### DIFF
--- a/AzurePipelines/Publish.UPM.yml
+++ b/AzurePipelines/Publish.UPM.yml
@@ -16,7 +16,7 @@ pool:
 steps:
 - task: Npm@1
 # Only update the version on master branch
-  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master') 
+  condition: not(startsWith(variables['Build.SourceBranch'], 'refs/heads/stabilization/'))
   inputs:
     command: 'custom'
     customCommand: --no-git-tag-version version prerelease --preid=$(Build.BuildNumber)

--- a/AzurePipelines/Publish.UPM.yml
+++ b/AzurePipelines/Publish.UPM.yml
@@ -16,7 +16,7 @@ pool:
 steps:
 - task: Npm@1
 # Only update the version on master branch
-  condition: not(startsWith(variables['Build.SourceBranch'], 'refs/heads/stabilization/'))
+  condition: not(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))
   inputs:
     command: 'custom'
     customCommand: --no-git-tag-version version prerelease --preid=$(Build.BuildNumber)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This scenario leverages the MSBuildForUnity [Project Builder](#msbuild-project-b
         ```
     - Add the following to the `dependencies` section of the file:
         ```json
-          "com.microsoft.msbuildforunity": "0.1.1-20190816.2.0"
+          "com.microsoft.msbuildforunity": "0.8.1"
         ```
 1. Create a "SDK style" MSBuild project (e.g. csproj) somewhere under your `Assets` directory of your Unity project that references the `MSBuildForUnity` NuGet package. Here is an example:
     ```xml
@@ -77,7 +77,7 @@ This scenario leverages the MSBuildForUnity [Project Builder](#msbuild-project-b
             <TargetFramework>netstandard2.0</TargetFramework>
         </PropertyGroup>
         <ItemGroup>
-            <PackageReference Include="MSBuildForUnity" Version="1.0.0">
+            <PackageReference Include="MSBuildForUnity" Version="0.8.1">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
             </PackageReference>

--- a/Samples/SimpleNuGetDependency.Unity/Assets/NewtonsoftDependency/NewtonsoftDependency.csproj
+++ b/Samples/SimpleNuGetDependency.Unity/Assets/NewtonsoftDependency/NewtonsoftDependency.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MSBuildForUnity" Version="[0.8.0-*, 0.8.0]">
+    <PackageReference Include="MSBuildForUnity" Version="[0.8.1-*, 0.8.1]">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
+++ b/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
@@ -35,12 +35,12 @@
     
     <Version>$(MajorVersion).$(MinorVersion).$(RevisionVersion)</Version>
     <!-- Version is based on Major.Minor.Revision as defined above, however, in a lab BUILD_BUILDID will be set so we pull in that as the pre-release version. -->
-    <Version Condition="'$(BUILD_BUILDID)' != '' And '$(Build_SourceBranchName.StartsWith('stabilization/')' == 'false'">$(Version)-$(BUILD_BUILDID)</Version>
+    <Version Condition="'$(BUILD_BUILDID)' != '' And !$(Build_SourceBranchName.StartsWith('stabilization/'))">$(Version)-$(BUILD_BUILDID)</Version>
 
     <PackageVersion>$(Version)</PackageVersion>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion)</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion).$(RevisionVersion).0</AssemblyFileVersion>
-    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' And '$(Build_SourceBranchName.StartsWith('stabilization/')' == 'false')">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
+    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' And !$(Build_SourceBranchName.StartsWith('stabilization/'))">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
+++ b/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
@@ -35,12 +35,12 @@
     
     <Version>$(MajorVersion).$(MinorVersion).$(RevisionVersion)</Version>
     <!-- Version is based on Major.Minor.Revision as defined above, however, in a lab BUILD_BUILDID will be set so we pull in that as the pre-release version. -->
-    <Version Condition="'$(BUILD_BUILDID)' != '' And '$(BUILD_ISRELEASEBUILD)' == ''">$(Version)-$(BUILD_BUILDID)</Version>
+    <Version Condition="'$(BUILD_BUILDID)' != '' And '$(Build_SourceBranchName.StartsWith('stabilization/')' == 'false'">$(Version)-$(BUILD_BUILDID)</Version>
 
     <PackageVersion>$(Version)</PackageVersion>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion)</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion).$(RevisionVersion).0</AssemblyFileVersion>
-    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' And '$(BUILD_ISRELEASEBUILD)' == ''">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
+    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' And '$(Build_SourceBranchName.StartsWith('stabilization/')'' == 'false')">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
+++ b/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
@@ -35,12 +35,12 @@
     
     <Version>$(MajorVersion).$(MinorVersion).$(RevisionVersion)</Version>
     <!-- Version is based on Major.Minor.Revision as defined above, however, in a lab BUILD_BUILDID will be set so we pull in that as the pre-release version. -->
-    <Version Condition="'$(BUILD_BUILDID)' != ''">$(Version)-$(BUILD_BUILDID)</Version>
+    <Version Condition="'$(BUILD_BUILDID)' != '' && '$(BUILD_ISRELEASEBUILD)' == ''">$(Version)-$(BUILD_BUILDID)</Version>
 
     <PackageVersion>$(Version)</PackageVersion>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion)</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion).$(RevisionVersion).0</AssemblyFileVersion>
-    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != ''">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
+    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' && '$(BUILD_ISRELEASEBUILD)' == ''">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
+++ b/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
@@ -40,7 +40,7 @@
     <PackageVersion>$(Version)</PackageVersion>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion)</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion).$(RevisionVersion).0</AssemblyFileVersion>
-    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' And '$(Build_SourceBranchName.StartsWith('stabilization/')'' == 'false')">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
+    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' And '$(Build_SourceBranchName.StartsWith('stabilization/')' == 'false')">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
+++ b/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
@@ -35,12 +35,12 @@
     
     <Version>$(MajorVersion).$(MinorVersion).$(RevisionVersion)</Version>
     <!-- Version is based on Major.Minor.Revision as defined above, however, in a lab BUILD_BUILDID will be set so we pull in that as the pre-release version. -->
-    <Version Condition="'$(BUILD_BUILDID)' != '' And !$(Build_SourceBranchName.StartsWith('stabilization/'))">$(Version)-$(BUILD_BUILDID)</Version>
+    <Version Condition="'$(BUILD_BUILDID)' != '' And !$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/stabilization/'))">$(Version)-$(BUILD_BUILDID)</Version>
 
     <PackageVersion>$(Version)</PackageVersion>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion)</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion).$(RevisionVersion).0</AssemblyFileVersion>
-    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' And !$(Build_SourceBranchName.StartsWith('stabilization/'))">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
+    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' And !$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/stabilization/'))">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
+++ b/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
@@ -31,16 +31,16 @@
     <MinorVersion>8</MinorVersion>
 
     <!-- Revision (semver Patch) version is hard-coded and should be incremented when a bug fix is made.-->
-    <RevisionVersion>0</RevisionVersion>
+    <RevisionVersion>1</RevisionVersion>
     
     <Version>$(MajorVersion).$(MinorVersion).$(RevisionVersion)</Version>
     <!-- Version is based on Major.Minor.Revision as defined above, however, in a lab BUILD_BUILDID will be set so we pull in that as the pre-release version. -->
-    <Version Condition="'$(BUILD_BUILDID)' != '' And !$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/stabilization/'))">$(Version)-$(BUILD_BUILDID)</Version>
+    <Version Condition="'$(BUILD_BUILDID)' != '' And !$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/'))">$(Version)-$(BUILD_BUILDID)</Version>
 
     <PackageVersion>$(Version)</PackageVersion>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion)</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion).$(RevisionVersion).0</AssemblyFileVersion>
-    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' And !$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/stabilization/'))">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
+    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' And !$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/'))">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
+++ b/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
@@ -35,12 +35,12 @@
     
     <Version>$(MajorVersion).$(MinorVersion).$(RevisionVersion)</Version>
     <!-- Version is based on Major.Minor.Revision as defined above, however, in a lab BUILD_BUILDID will be set so we pull in that as the pre-release version. -->
-    <Version Condition="'$(BUILD_BUILDID)' != '' && '$(BUILD_ISRELEASEBUILD)' == ''">$(Version)-$(BUILD_BUILDID)</Version>
+    <Version Condition="'$(BUILD_BUILDID)' != '' And '$(BUILD_ISRELEASEBUILD)' == ''">$(Version)-$(BUILD_BUILDID)</Version>
 
     <PackageVersion>$(Version)</PackageVersion>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion)</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion).$(RevisionVersion).0</AssemblyFileVersion>
-    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' && '$(BUILD_ISRELEASEBUILD)' == ''">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
+    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' And '$(BUILD_ISRELEASEBUILD)' == ''">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/DependenciesProjectTemplate.g.props.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/DependenciesProjectTemplate.g.props.template
@@ -20,7 +20,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MSBuildForUnity" Version="[0.8.0-*, 0.8.0]">
+    <PackageReference Include="MSBuildForUnity" Version="[0.8.1-*, 0.8.1]">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/MSBuildForUnity.Common.props.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/MSBuildForUnity.Common.props.template
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <MSBuildForUnityVersion>0.8.0</MSBuildForUnityVersion>
+    <MSBuildForUnityVersion>0.8.1</MSBuildForUnityVersion>
     
     <MSBuildForUnityGeneratedOutputDirectory><!--GENERATED_OUTPUT_DIRECTORY_TOKEN--></MSBuildForUnityGeneratedOutputDirectory>
     <UnityProjectAssetsPath><!--UNITY_PROJECT_ASSETS_PATH_TOKEN--></UnityProjectAssetsPath>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/package.json
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.microsoft.msbuildforunity",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "displayName": "MSBuild for Unity",
     "description": "MSBuildForUnity solves the problem of establishing clear dependency relationships between Unity project and other .NET components such as external (to Unity) C# projects, or NuGet packages. It creates a familiar to .NET developers project structure and ensures that the dependencies are resolved and brought into the Unity project as appropriate.",
     "unity": "2018.1",


### PR DESCRIPTION
I updated the building rules for CIs that would not increment (or append) the prerelease version unless we are on "release/" branch. I had to up the version to 0.8.1 because I realized I pushed 0.8.0 deleted, and now can't push it.