### PR TITLE
Fix Platform and TargetFramework switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This scenario leverages the MSBuildForUnity [Project Builder](#msbuild-project-b
         ```
     - Add the following to the `dependencies` section of the file:
         ```json
-          "com.microsoft.msbuildforunity": "0.8.1"
+          "com.microsoft.msbuildforunity": "0.8.2"
         ```
 1. Create a "SDK style" MSBuild project (e.g. csproj) somewhere under your `Assets` directory of your Unity project that references the `MSBuildForUnity` NuGet package. Here is an example:
     ```xml
@@ -77,7 +77,7 @@ This scenario leverages the MSBuildForUnity [Project Builder](#msbuild-project-b
             <TargetFramework>netstandard2.0</TargetFramework>
         </PropertyGroup>
         <ItemGroup>
-            <PackageReference Include="MSBuildForUnity" Version="0.8.1">
+            <PackageReference Include="MSBuildForUnity" Version="0.8.2">
                 <PrivateAssets>all</PrivateAssets>
                 <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
             </PackageReference>

--- a/Samples/SimpleNuGetDependency.Unity/Assets/NewtonsoftDependency/NewtonsoftDependency.csproj
+++ b/Samples/SimpleNuGetDependency.Unity/Assets/NewtonsoftDependency/NewtonsoftDependency.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MSBuildForUnity" Version="[0.8.1-*, 0.8.1]">
+    <PackageReference Include="MSBuildForUnity" Version="[0.8.2-*, 0.8.2]">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/DependenciesProjectTemplate.g.props.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/DependenciesProjectTemplate.g.props.template
@@ -17,6 +17,8 @@
     <BaseIntermediateOutputPath>$(MSBuildForUnityGeneratedOutputDirectory)\..\Output\obj\Dependencies</BaseIntermediateOutputPath>
     <OutputPath>Dependencies</OutputPath>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <!--Copy the NuGet package reference dlls as well.-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/DependenciesProjectTemplate.g.props.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/DependenciesProjectTemplate.g.props.template
@@ -20,7 +20,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MSBuildForUnity" Version="[0.8.1-*, 0.8.1]">
+    <PackageReference Include="MSBuildForUnity" Version="[0.8.2-*, 0.8.2]">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/MSBuildForUnity.Common.props.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/MSBuildForUnity.Common.props.template
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <MSBuildForUnityVersion>0.8.1</MSBuildForUnityVersion>
+    <MSBuildForUnityVersion>0.8.2</MSBuildForUnityVersion>
     
     <MSBuildForUnityGeneratedOutputDirectory><!--GENERATED_OUTPUT_DIRECTORY_TOKEN--></MSBuildForUnityGeneratedOutputDirectory>
     <UnityProjectAssetsPath><!--UNITY_PROJECT_ASSETS_PATH_TOKEN--></UnityProjectAssetsPath>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/MSBuildForUnity.Common.props.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/MSBuildForUnity.Common.props.template
@@ -12,4 +12,8 @@
     <UnityMajorVersion><!--UNITY_MAJOR_VERSION_TOKEN--></UnityMajorVersion>
     <UnityMinorVersion><!--UNITY_MINOR_VERSION_TOKEN--></UnityMinorVersion>
   </PropertyGroup>
+  
+  <Target Name="_RemoveOutputDirectory" AfterTargets="Clean">
+    <RemoveDir Directories="$(OutputPath)"/>
+  </Target>
 </Project>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
@@ -158,7 +158,6 @@ namespace Microsoft.Build.Unity.ProjectGeneration
 
             if (shouldClean)
             {
-                Debug.Log("Doing a clean");
                 // We clean up previous build if the EditorPrefs currentBuildTarget or targetFramework is different from current ones.
                 MSBuildProjectBuilder.TryBuildAllProjects(MSBuildProjectBuilder.CleanProfileName);
             }
@@ -193,7 +192,6 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             // If we cleaned, now build
             if (shouldClean)
             {
-                Debug.Log("Doing a build after clean");
                 MSBuildProjectBuilder.TryBuildAllProjects(MSBuildProjectBuilder.BuildProfileName);
             }
         }

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/package.json
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.microsoft.msbuildforunity",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "displayName": "MSBuild for Unity",
     "description": "MSBuildForUnity solves the problem of establishing clear dependency relationships between Unity project and other .NET components such as external (to Unity) C# projects, or NuGet packages. It creates a familiar to .NET developers project structure and ensures that the dependencies are resolved and brought into the Unity project as appropriate.",
     "unity": "2018.1",


### PR DESCRIPTION
This change improves how the project handles platform and target framework (API Compatibility set) changes. Furthermore, it makes sure to appropriately clean-up before making the switch.

This increments the version to 0.8.2 for the hotfix.

This PR is against the prerelease/0.8.2 branch which is essentially the release/0.8.1. Once we approve, I will rename prerelease/0.8.2 to release/0.8.2 and push a release.