### PR TITLE
This change fixes the issue with spaces in project path

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectReferenceEditor.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectReferenceEditor.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Build.Unity
                             var pickedUri = new Uri(pickedPath);
                             var relativeUri = assetUri.MakeRelativeUri(pickedUri);
 
-                            projectPathProperty.stringValue = relativeUri.ToString();
+                            projectPathProperty.stringValue = Uri.UnescapeDataString(relativeUri.ToString());
                         }
                     }
                 }

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Exporters/TemplatedProjectExporter.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Exporters/TemplatedProjectExporter.cs
@@ -432,10 +432,10 @@ namespace Microsoft.Build.Unity.ProjectGeneration.Exporters
 
                 TemplateReplacementSet replacementSet = pluginReferenceTemplatePart.CreateReplacementSet(templateReplacementSet);
                 pluginReferenceTemplatePart.Tokens["REFERENCE"].AssignValue(replacementSet, dependency.Dependency.Name);
-                pluginReferenceTemplatePart.Tokens["HINT_PATH"].AssignValue(replacementSet, dependency.Dependency.ReferencePath.AbsolutePath);
+                pluginReferenceTemplatePart.Tokens["HINT_PATH"].AssignValue(replacementSet, dependency.Dependency.ReferencePath.LocalPath);
                 pluginReferenceTemplatePart.Tokens["CONDITION"].AssignValue(replacementSet, platformConditions.Count == 0 ? "false" : string.Join(" OR ", platformConditions));
 
-                additionalSearchPaths.Add(Path.GetDirectoryName(dependency.Dependency.ReferencePath.AbsolutePath));
+                additionalSearchPaths.Add(Path.GetDirectoryName(dependency.Dependency.ReferencePath.LocalPath));
             }
 
             templatePart.Tokens["REFERENCE_CONFIGURATION"].AssignValue(templateReplacementSet, inEditor ? "InEditor" : "Player");

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/PluginAssemblyInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/PluginAssemblyInfo.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             // This approach doesn't work for native YAML parsing
 
             Dictionary<string, bool> enabledPlatforms = new Dictionary<string, bool>();
-            using (StreamReader reader = new StreamReader(ReferencePath.AbsolutePath + ".meta"))
+            using (StreamReader reader = new StreamReader(ReferencePath.LocalPath + ".meta"))
             {
                 DefineConstraints = new HashSet<string>();
 
@@ -271,7 +271,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 }
                 else
                 {
-                    Debug.LogError($"Platform '{platformName}' was specified as enabled by '{ReferencePath.AbsolutePath}' plugin, but not available in processed compilation settings.");
+                    Debug.LogError($"Platform '{platformName}' was specified as enabled by '{ReferencePath.LocalPath}' plugin, but not available in processed compilation settings.");
                 }
             }
         }

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Utilities.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Utilities.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 thisAbsolute = thisAbsolute + "\\";
             }
 
-            return GetNormalizedPath(new Uri(thisAbsolute).MakeRelativeUri(new Uri(thatAbsolute)).OriginalString);
+            return GetNormalizedPath(Uri.UnescapeDataString(new Uri(thisAbsolute).MakeRelativeUri(new Uri(thatAbsolute)).OriginalString));
         }
 
         /// <summary>


### PR DESCRIPTION
This change consists of two items:
- MakeRelativeURI will produce escaped strings, so I unescape that.
- AbsoulutePath will produce excaped strings, so I use LocalPath instead