### PR TITLE
Version Synchronization (MSBuild)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,31 @@
+<Project>
+
+  <PropertyGroup>
+    <!-- 
+      The following three properties are manually set:
+       - Major is hard-coded and should be incremented on breaking changes.
+       - Minor version is hard-coded and should be incremented on feature additions that aren't breaking changes.
+       - Revision (semver Patch) version is hard-coded and should be incremented when a bug fix is made.
+    -->
+    <MSB4U_MajorVersion>0</MSB4U_MajorVersion>
+    <MSB4U_MinorVersion>8</MSB4U_MinorVersion>
+    <MSB4U_RevisionVersion>3</MSB4U_RevisionVersion>
+    <MSB4U_RevisionVersion_PreIncrement>3</MSB4U_RevisionVersion_PreIncrement>
+    
+    <!-- If we are not on a release branch, we increment revision version -->
+    <MSB4U_RevisionVersion Condition="!$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/'))">$([MSBuild]::Add($(MSB4U_RevisionVersion), 1))</MSB4U_RevisionVersion>
+    
+    <MSB4U_Version>$(MSB4U_MajorVersion).$(MSB4U_MinorVersion).$(MSB4U_RevisionVersion)</MSB4U_Version>
+    <!-- Version is based on Major.Minor.Revision as defined above, however, in a lab BUILD_BUILDID will be set so we pull in that as the pre-release version. -->
+    <MSB4U_Version Condition="'$(BUILD_BUILDID)' != '' And !$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/'))">$(MSB4U_Version)-$(BUILD_BUILDID)</MSB4U_Version>
+
+    <MSB4U_PackageVersion>$(MSB4U_Version)</MSB4U_PackageVersion>
+    <MSB4U_AssemblyVersion>$(MSB4U_MajorVersion).$(MSB4U_MinorVersion)</MSB4U_AssemblyVersion>
+    <MSB4U_AssemblyFileVersion>$(MSB4U_AssemblyVersion).$(MSB4U_RevisionVersion).0</MSB4U_AssemblyFileVersion>
+    <MSB4U_AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' And !$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/'))">$(MSB4U_AssemblyVersion).$(MSB4U_RevisionVersion).$(BUILD_BUILDID)</MSB4U_AssemblyFileVersion>
+    
+    <MSB4U_DependencyVersion>$(MSB4U_MajorVersion).$(MSB4U_MinorVersion).$(MSB4U_RevisionVersion)</MSB4U_DependencyVersion>
+    <MSB4U_DependencyVersion Condition="!$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/'))">[$(MSB4U_MajorVersion).$(MSB4U_MinorVersion).$(MSB4U_RevisionVersion_PreIncrement), $(MSB4U_MajorVersion).$(MSB4U_MinorVersion).$(MSB4U_RevisionVersion)]</MSB4U_DependencyVersion>
+  </PropertyGroup>
+
+</Project>

--- a/Samples/SimpleNuGetDependency.Unity/Assets/NewtonsoftDependency/NewtonsoftDependency.csproj
+++ b/Samples/SimpleNuGetDependency.Unity/Assets/NewtonsoftDependency/NewtonsoftDependency.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MSBuildForUnity" Version="[0.8.3-*, 0.8.3]">
+    <PackageReference Include="MSBuildForUnity" Version="$(MSB4U_DependencyVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
+++ b/Source/MSBuildTools.Unity.NuGet/MSBuildForUnity.csproj
@@ -24,23 +24,16 @@
 
   <!-- Setup the versioning for the package based on the build number if provided -->
   <PropertyGroup>
-    <!-- Major is hard-coded and should be incremented on breaking changes -->
-    <MajorVersion>0</MajorVersion>
-
-    <!-- Minor version is hard-coded and should be incremented on feature additions that aren't breaking changes.-->
-    <MinorVersion>8</MinorVersion>
-
-    <!-- Revision (semver Patch) version is hard-coded and should be incremented when a bug fix is made.-->
-    <RevisionVersion>3</RevisionVersion>
+    <!-- These values are set up from the repo-root Directory.Build.props file -->
+    <MajorVersion>$(MSB4U_MajorVersion)</MajorVersion>
+    <MinorVersion>$(MSB4U_MinorVersion)</MinorVersion>
+    <RevisionVersion>$(MSB4U_RevisionVersion)</RevisionVersion>
     
-    <Version>$(MajorVersion).$(MinorVersion).$(RevisionVersion)</Version>
-    <!-- Version is based on Major.Minor.Revision as defined above, however, in a lab BUILD_BUILDID will be set so we pull in that as the pre-release version. -->
-    <Version Condition="'$(BUILD_BUILDID)' != '' And !$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/'))">$(Version)-$(BUILD_BUILDID)</Version>
+    <Version>$(MSB4U_Version)</Version>
 
-    <PackageVersion>$(Version)</PackageVersion>
-    <AssemblyVersion>$(MajorVersion).$(MinorVersion)</AssemblyVersion>
-    <AssemblyFileVersion>$(AssemblyVersion).$(RevisionVersion).0</AssemblyFileVersion>
-    <AssemblyFileVersion Condition="'$(BUILD_BUILDID)' != '' And !$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/'))">$(AssemblyVersion).$(RevisionVersion).$(BUILD_BUILDID)</AssemblyFileVersion>
+    <PackageVersion>$(MSB4U_PackageVersion)</PackageVersion>
+    <AssemblyVersion>$(MSB4U_AssemblyVersion)</AssemblyVersion>
+    <AssemblyFileVersion>$(MSB4U_AssemblyFileVersion)</AssemblyFileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change covers some of the goals of #56, only specifically aimed at MSBuild aspects. This means:
- There is a new Directory.Build.props file at the root to centralized the versioning info
- The MSBuildForUnity.NuGet package project will use this to set the appropriate version
- The sample SimpleNuGetDependency will also rely on this to set it's dependency.

  Additionally, this change also auto-increments the patch version on non-release branches.

This change doesn't cover the following:
- Mechanism for updating the templates used in generation that are part of MSBuildForUnity NPM package
- Mechanism for keeping the NPM package.json version in sync