### PR TITLE
Small fixes related to editor only scripts and non MRTK projects

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/SDKProjectTemplate.g.props.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/SDKProjectTemplate.g.props.template
@@ -130,7 +130,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="##PROJECT_DIRECTORY_PATH_TOKEN##\**\*.cs" Exclude="@(FoldersToExclude->'%(identity)\**\*.cs')" />
+    <Compile Include="##PROJECT_DIRECTORY_PATH_TOKEN##\**\*.cs"
+             Exclude="@(FoldersToExclude->'%(identity)\**\*.cs');**\Editor\**\*.cs"
+             Condition="'$(UnityConfiguration)'=='Player'"/>
+    <Compile Include="##PROJECT_DIRECTORY_PATH_TOKEN##\**\*.cs"
+             Exclude="@(FoldersToExclude->'%(identity)\**\*.cs')"
+             Condition="'$(UnityConfiguration)'=='InEditor'"/>
     <!--<Content Include="$(ProjectGuid).csmap">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>-->

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/SDKProjectTemplate.g.props.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/SDKProjectTemplate.g.props.template
@@ -130,12 +130,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="##PROJECT_DIRECTORY_PATH_TOKEN##\**\*.cs"
-             Exclude="@(FoldersToExclude->'%(identity)\**\*.cs');**\Editor\**\*.cs"
-             Condition="'$(UnityConfiguration)'=='Player'"/>
-    <Compile Include="##PROJECT_DIRECTORY_PATH_TOKEN##\**\*.cs"
-             Exclude="@(FoldersToExclude->'%(identity)\**\*.cs')"
-             Condition="'$(UnityConfiguration)'=='InEditor'"/>
+    <Compile Include="##PROJECT_DIRECTORY_PATH_TOKEN##\**\*.cs" Exclude="@(FoldersToExclude->'%(identity)\**\*.cs')" />
     <!--<Content Include="$(ProjectGuid).csmap">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>-->

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/AssetScriptReferenceRetargeter.cs
@@ -336,7 +336,8 @@ namespace Microsoft.Build.Unity.ProjectGeneration
 
                 foreach (Assembly dll in dlls)
                 {
-                    if (dll.name.Contains("MixedReality"))
+                    // TODO - this should be improved/it won't work for non microsoft dlls
+                    if (dll.name.Contains("Microsoft.MixedReality"))
                     {
                         string dllPath = Utilities.GetFullPathFromAssetsRelative($"Assets/../MSBuild/Publish/InEditor/WindowsStandalone32/{dll.name}.dll");
                         File.Copy(dllPath, Path.Combine(tmpDirPath, $"{dll.name}.dll"), true);
@@ -374,9 +375,9 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                                 {
                                     Debug.LogError($"Encountered a MonoScript we get a null Type from: '{monoScript.name}'");
                                 }
-                                else if (type.Namespace == null || !type.Namespace.Contains("Microsoft.MixedReality.Toolkit"))
+                                else if (type.Namespace == null || !type.Namespace.Contains("Microsoft.MixedReality"))
                                 {
-                                    throw new InvalidDataException($"Type {type.Name} is not a member of the Microsoft.MixedReality.Toolkit namespace");
+                                    throw new InvalidDataException($"Type {type.Name} is not a member of the Microsoft.MixedReality namespace");
                                 }
                                 else
                                 {

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/AssetScriptReferenceRetargeter.cs
@@ -375,10 +375,6 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                                 {
                                     Debug.LogError($"Encountered a MonoScript we get a null Type from: '{monoScript.name}'");
                                 }
-                                else if (type.Namespace == null || !type.Namespace.Contains("Microsoft.MixedReality"))
-                                {
-                                    throw new InvalidDataException($"Type {type.Name} is not a member of the Microsoft.MixedReality namespace");
-                                }
                                 else
                                 {
                                     assemblyInformation.CompiledClasses.Add(type.FullName, new ClassInformation() { Name = type.Name, Namespace = type.Namespace, FileId = fileId, Guid = newDllGuid });
@@ -424,8 +420,8 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 }
                 Directory.CreateDirectory(pluginPath);
 
-                CopyFiles(directory, pluginPath, "Microsoft.MixedReality.Toolkit*.dll");
-                CopyFiles(directory, pluginPath, "Microsoft.MixedReality.Toolkit*.pdb");
+                CopyFiles(directory, pluginPath, "Microsoft.MixedReality*.dll");
+                CopyFiles(directory, pluginPath, "Microsoft.MixedReality*.pdb");
             }
         }
 

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
@@ -62,10 +62,10 @@ namespace Microsoft.Build.Unity.ProjectGeneration
 
             public void OnActiveBuildTargetChanged(BuildTarget previousTarget, BuildTarget newTarget)
             {
-                if (EditorAnalyticsSessionInfo.elapsedTime > 0)
-                {
-                    RefreshGeneratedOutput(forceGenerateEverything: Config.AutoGenerateEnabled);
-                }
+                // if (EditorAnalyticsSessionInfo.elapsedTime > 0)
+                // {
+                //     RefreshGeneratedOutput(forceGenerateEverything: Config.AutoGenerateEnabled);
+                // }
             }
         }
 
@@ -135,6 +135,12 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             }
         }
 
+        public static void RegenerateSDKProjects()
+        {
+            RegenerateEverything(reparseUnityData:true);
+            Debug.Log($"{nameof(RegenerateSDKProjects)} Completed Succesfully.");
+        }
+
         static MSBuildTools()
         {
             if (EditorAnalyticsSessionInfo.elapsedTime == 0)
@@ -170,7 +176,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             bool shouldClean = EditorPrefs.GetInt($"{nameof(MSBuildTools)}.{nameof(currentBuildTarget)}") != (int)currentBuildTarget
                 || EditorPrefs.GetInt($"{nameof(MSBuildTools)}.{nameof(targetFramework)}") != (int)targetFramework
                 || forceGenerateEverything;
-
+                        
             if (shouldClean)
             {
                 // We clean up previous build if the EditorPrefs currentBuildTarget or targetFramework is different from current ones.

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
@@ -62,10 +62,10 @@ namespace Microsoft.Build.Unity.ProjectGeneration
 
             public void OnActiveBuildTargetChanged(BuildTarget previousTarget, BuildTarget newTarget)
             {
-                // if (EditorAnalyticsSessionInfo.elapsedTime > 0)
-                // {
-                //     RefreshGeneratedOutput(forceGenerateEverything: Config.AutoGenerateEnabled);
-                // }
+                if (EditorAnalyticsSessionInfo.elapsedTime > 0)
+                {
+                    RefreshGeneratedOutput(forceGenerateEverything: Config.AutoGenerateEnabled);
+                }
             }
         }
 

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 }
             }
 
-            RefreshProjects();
+            //RefreshProjects();
         }
 
         public void RefreshProjects()
@@ -260,11 +260,13 @@ namespace Microsoft.Build.Unity.ProjectGeneration
 
             if (!assemblyDefinitionInfo.BuiltInPackage)
             {
-                Uri dependencies = new Uri(Path.Combine(Utilities.AssetPath, "Dependencies"));
+                Uri dependencies = new Uri(Path.Combine(Utilities.AssetPath, "Dependencies\\"));
                 foreach (PluginAssemblyInfo plugin in Plugins.Where(t => t.Type != PluginType.Native))
                 {
+                    Debug.Log($"Plugin: {plugin.Name} {plugin.Type} {plugin.AutoReferenced} {plugin.ReferencePath}");
                     if (!dependencies.IsBaseOf(plugin.ReferencePath) && (plugin.AutoReferenced || assemblyDefinitionInfo.PrecompiledAssemblyReferences.Contains(plugin.Name)))
                     {
+                        Debug.Log($"Plugin referenced: {plugin.Name}");
                         toReturn.AddDependency(plugin);
                     }
                 }

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
@@ -265,10 +265,8 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 Uri dependencies = new Uri(Path.Combine(Utilities.AssetPath, "Dependencies\\"));
                 foreach (PluginAssemblyInfo plugin in Plugins.Where(t => t.Type != PluginType.Native))
                 {
-                    Debug.Log($"Plugin: {plugin.Name} {plugin.Type} {plugin.AutoReferenced} {plugin.ReferencePath}");
                     if (!dependencies.IsBaseOf(plugin.ReferencePath) && (plugin.AutoReferenced || assemblyDefinitionInfo.PrecompiledAssemblyReferences.Contains(plugin.Name)))
                     {
-                        Debug.Log($"Plugin referenced: {plugin.Name}");
                         toReturn.AddDependency(plugin);
                     }
                 }

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 }
             }
 
-            //RefreshProjects();
+            RefreshProjects();
         }
 
         public void RefreshProjects()


### PR DESCRIPTION
These changes are related to unblocking MSB4U usage in the MixedReality-SpectatorView repo.

1) Asset retargeting appears to have been written originally with the mixed reality toolkit in mind. This change removes some toolkit specific paths. However, this fix does not solve things for asmdefs that don't have a Microsoft.MixedReality* prefix.
2) A RegenerateSDKProjects function has been added that can be called from the command line. GenerateSDKProjects seems to run indefinitely when called from a cmd window.