### PR TITLE
Add Winmd support

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/CSProjectInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/CSProjectInfo.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
     {
         private readonly List<CSProjectDependency<CSProjectInfo>> csProjectDependencies = new List<CSProjectDependency<CSProjectInfo>>();
         private readonly List<CSProjectDependency<PluginAssemblyInfo>> pluginAssemblyDependencies = new List<CSProjectDependency<PluginAssemblyInfo>>();
+        private readonly List<CSProjectDependency<WinMDInfo>> winmdDependencies = new List<CSProjectDependency<WinMDInfo>>();
 
         /// <summary>
         /// The associated Assembly-Definition info if available.
@@ -62,6 +63,8 @@ namespace Microsoft.Build.Unity.ProjectGeneration
         public IReadOnlyCollection<CSProjectDependency<CSProjectInfo>> ProjectDependencies { get; }
 
         public IReadOnlyCollection<CSProjectDependency<PluginAssemblyInfo>> PluginDependencies { get; }
+
+        public IReadOnlyCollection<CSProjectDependency<WinMDInfo>> WinMDDependencies { get; }
 
         /// <summary>
         /// Creates a new instance of the CSProject info.
@@ -87,6 +90,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
 
             ProjectDependencies = new ReadOnlyCollection<CSProjectDependency<CSProjectInfo>>(csProjectDependencies);
             PluginDependencies = new ReadOnlyCollection<CSProjectDependency<PluginAssemblyInfo>>(pluginAssemblyDependencies);
+            WinMDDependencies = new ReadOnlyCollection<CSProjectDependency<WinMDInfo>>(winmdDependencies);
         }
 
         private ProjectType GetProjectType(AssemblyDefinitionInfo assemblyDefinitionInfo)
@@ -159,6 +163,15 @@ namespace Microsoft.Build.Unity.ProjectGeneration
         internal void AddDependency(PluginAssemblyInfo pluginAssemblyInfo)
         {
             AddDependency(pluginAssemblyDependencies, pluginAssemblyInfo);
+        }
+
+        /// <summary>
+        /// Adds a dependency to the project.
+        /// </summary>
+        /// <param name="winmdInfo">The winmd dependency.</param>
+        internal void AddDependency(WinMDInfo winmdInfo)
+        {
+            AddDependency(winmdDependencies, winmdInfo);
         }
 
         private void AddDependency<T>(List<CSProjectDependency<T>> items, T referenceInfo) where T : ReferenceItemInfo

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Exporters/TemplatedProjectExporter.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Exporters/TemplatedProjectExporter.cs
@@ -438,6 +438,18 @@ namespace Microsoft.Build.Unity.ProjectGeneration.Exporters
                 additionalSearchPaths.Add(Path.GetDirectoryName(dependency.Dependency.ReferencePath.LocalPath));
             }
 
+            foreach (CSProjectDependency<WinMDInfo> dependency in projectInfo.WinMDDependencies)
+            {
+                List<string> platformConditions = GetPlatformConditions(inEditor ? projectInfo.InEditorPlatforms : projectInfo.PlayerPlatforms, inEditor ? dependency.InEditorSupportedPlatforms : dependency.PlayerSupportedPlatforms);
+
+                TemplateReplacementSet replacementSet = pluginReferenceTemplatePart.CreateReplacementSet(templateReplacementSet);
+                pluginReferenceTemplatePart.Tokens["REFERENCE"].AssignValue(replacementSet, dependency.Dependency.Name);
+                pluginReferenceTemplatePart.Tokens["HINT_PATH"].AssignValue(replacementSet, dependency.Dependency.ReferencePath.LocalPath);
+                pluginReferenceTemplatePart.Tokens["CONDITION"].AssignValue(replacementSet, platformConditions.Count == 0 ? "false" : string.Join(" OR ", platformConditions));
+
+                additionalSearchPaths.Add(Path.GetDirectoryName(dependency.Dependency.ReferencePath.LocalPath));
+            }
+
             templatePart.Tokens["REFERENCE_CONFIGURATION"].AssignValue(templateReplacementSet, inEditor ? "InEditor" : "Player");
         }
 

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
@@ -273,10 +273,8 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 Uri dependencies = new Uri(Path.Combine(Utilities.AssetPath, "Dependencies\\"));
                 foreach (PluginAssemblyInfo plugin in Plugins.Where(t => t.Type != PluginType.Native))
                 {
-                    Debug.Log($"Plugin: {plugin.Name} {plugin.Type} {plugin.AutoReferenced} {plugin.ReferencePath}");
                     if (!dependencies.IsBaseOf(plugin.ReferencePath) && (plugin.AutoReferenced || assemblyDefinitionInfo.PrecompiledAssemblyReferences.Contains(plugin.Name)))
                     {
-                        Debug.Log($"Plugin referenced: {plugin.Name}");
                         toReturn.AddDependency(plugin);
                     }
                 }

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                         }
                         else
                         {
-                            Debug.LogWarning($"References to {winmd} were excluded because the winmd is configured incorrectly.");
+                            Debug.LogError($"References to {winmd} were excluded because the winmd is configured incorrectly. Make sure this winmd is setup to only support WSAPlayer in the Unity inspector.");
                         }
                     }
                 }

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             plugins = new List<PluginAssemblyInfo>();
             winmds = new List<WinMDInfo>();
 
-            IEnumerable<string> assetReferences = Directory.GetFiles(Utilities.AssetPath, "*.*", SearchOption.AllDirectories)
+            IEnumerable<string> assetReferences = Directory.EnumerateFiles(Utilities.AssetPath, "*.*", SearchOption.AllDirectories)
                 .Where(file => file.ToLower().EndsWith(".dll") || file.ToLower().EndsWith(".winmd"));
             foreach (string assetPath in assetReferences)
             {
@@ -341,7 +341,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 }
             }
 
-            IEnumerable<string> packageReferences = Directory.GetFiles(Utilities.PackageLibraryCachePath, "*.*", SearchOption.AllDirectories)
+            IEnumerable<string> packageReferences = Directory.EnumerateFiles(Utilities.PackageLibraryCachePath, "*.*", SearchOption.AllDirectories)
                 .Where(file => file.ToLower().EndsWith(".dll") || file.ToLower().EndsWith(".winmd"));
             foreach (string packagePath in packageReferences)
             {

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
@@ -283,7 +283,14 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 {
                     if (!dependencies.IsBaseOf(winmd.ReferencePath))
                     {
-                        toReturn.AddDependency(winmd);
+                        if (winmd.IsValid)
+                        {
+                            toReturn.AddDependency(winmd);
+                        }
+                        else
+                        {
+                            Debug.LogWarning($"References to {winmd} were excluded because the winmd is configured incorrectly.");
+                        }
                     }
                 }
             }

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/WinMDInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/WinMDInfo.cs
@@ -1,0 +1,237 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.Build.Unity.ProjectGeneration
+{
+    /// <summary>
+    /// This is the information for the winmds in the Unity project.
+    /// </summary>
+    public class WinMDInfo : ReferenceItemInfo
+    {
+        /// <summary>
+        /// Gets the output path to the reference.
+        /// </summary>
+        public Uri ReferencePath { get; }
+
+        /// <summary>
+        /// If the plugin has define constraints, then it will only be referenced if the platform/project defines at least one of these constraints.
+        /// ! operator means that the specified plugin must not be included
+        /// https://docs.unity3d.com/ScriptReference/PluginImporter.DefineConstraints.html
+        /// </summary>
+        public HashSet<string> DefineConstraints { get; private set; }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="PluginAssemblyInfo"/>.
+        /// </summary>
+        public WinMDInfo(UnityProjectInfo unityProjectInfo, Guid guid, string fullPath)
+             : base(unityProjectInfo, guid, Path.GetFileNameWithoutExtension(fullPath))
+        {
+            ReferencePath = new Uri(fullPath);
+            ParseYAMLFile();
+        }
+
+        private void ParseYAMLFile()
+        {
+            Dictionary<string, bool> enabledPlatforms = new Dictionary<string, bool>();
+            using (StreamReader reader = new StreamReader(ReferencePath.LocalPath + ".meta"))
+            {
+                DefineConstraints = new HashSet<string>();
+
+                // Parse define constraints
+                string defineConstraints = reader.ReadUntil("defineConstraints:", "platformData:");
+                string platformData;
+                if (defineConstraints.Contains("defineConstraints:"))
+                {
+                    if (!defineConstraints.Contains("[]"))
+                    {
+                        reader.ReadWhile(line =>
+                        {
+                            line = line.Trim();
+                            if (line.StartsWith("-"))
+                            {
+                                string define = line.Substring(1).Trim();
+
+                                if (define.StartsWith("'") && define.EndsWith("'"))
+                                {
+                                    define = define.Substring(1, define.Length - 2);
+                                }
+
+                                DefineConstraints.Add(define);
+                                return true;
+                            }
+                            // else
+                            return false;
+                        });
+                    }
+
+                    // Since succeded, read until platformData
+                    platformData = reader.ReadUntil("platformData:");
+                }
+                else
+                {
+                    // If it's not defineConstraints, then it's one of the other 3
+                    platformData = defineConstraints;
+                }
+
+                if (!platformData.Contains("platformData:"))
+                {
+                    // Read until platform data
+                    reader.ReadUntil("platformData:");
+                }
+
+                ParsePlatformData(reader, enabledPlatforms);
+            }
+
+            Dictionary<BuildTarget, CompilationPlatformInfo> inEditorPlatforms = new Dictionary<BuildTarget, CompilationPlatformInfo>();
+            if (enabledPlatforms.TryGetValue("Editor", out bool platformEnabled) && platformEnabled)
+            {
+                foreach (CompilationPlatformInfo platform in UnityProjectInfo.AvailablePlatforms)
+                {
+                    inEditorPlatforms.Add(platform.BuildTarget, platform);
+                }
+            }
+
+            Dictionary<BuildTarget, CompilationPlatformInfo> playerPlatforms = new Dictionary<BuildTarget, CompilationPlatformInfo>();
+
+            TryAddEnabledPlatform(playerPlatforms, enabledPlatforms, "Win", BuildTarget.StandaloneWindows);
+            TryAddEnabledPlatform(playerPlatforms, enabledPlatforms, "Win64", BuildTarget.StandaloneWindows64);
+            TryAddEnabledPlatform(playerPlatforms, enabledPlatforms, "WindowsStoreApps", BuildTarget.WSAPlayer);
+            TryAddEnabledPlatform(playerPlatforms, enabledPlatforms, "iOS", BuildTarget.iOS);
+            TryAddEnabledPlatform(playerPlatforms, enabledPlatforms, "Android", BuildTarget.Android);
+
+            FilterPlatformsBasedOnDefineConstraints(inEditorPlatforms, true);
+            FilterPlatformsBasedOnDefineConstraints(playerPlatforms, false);
+
+            InEditorPlatforms = new ReadOnlyDictionary<BuildTarget, CompilationPlatformInfo>(inEditorPlatforms);
+            PlayerPlatforms = new ReadOnlyDictionary<BuildTarget, CompilationPlatformInfo>(playerPlatforms);
+        }
+
+        private void ParsePlatformData(StreamReader reader, Dictionary<string, bool> enabledPlatforms)
+        {
+            if (reader.ReadUntil("first:", "userData:").Contains("userData:") || reader.EndOfStream)
+            {
+                // We reached the end
+                return;
+            }
+
+            if (reader.ReadLine().Contains("'': Any")) // Try use exclude method
+            {
+                string settingsLine = reader.ReadUntil("settings:", "userData:");
+                if (settingsLine.Contains("userData:"))
+                {
+                    return;
+                }
+
+                // We are fine to use exclude method if we have a set of settings
+                if (!settingsLine.Contains("settings: {}"))
+                {
+                    reader.ReadWhile(l =>
+                    {
+                        if (l.Contains("Exclude"))
+                        {
+                            string[] parts = l.Trim().Replace("Exclude ", string.Empty).Split(':');
+                            enabledPlatforms.Add(parts[0], parts[1].Trim() == "0"); // These are exclude, so check for 0 if to include
+                            return true;
+                        }
+
+                        return false;
+                    });
+
+                    return;
+                }
+            }
+            // else fall through to use -first method 
+
+            string line;
+            while ((line = reader.ReadUntil("first:", "userData:")).Contains("first:") && !reader.EndOfStream)
+            {
+                string[] platformLineParts = reader.ReadLine().Split(':');
+                string platform = platformLineParts[1].Trim();
+
+                if (platformLineParts[0].Contains("Facebook"))
+                {
+                    platform = $"Facebook{platform}";
+                }
+                string enabledLine = reader.ReadUntil("enabled:");
+
+                enabledPlatforms.Add(platform, enabledLine.Split(':')[1].Trim() == "1");
+            }
+        }
+
+        private bool ContainsDefineHelper(string define, bool inEditor, CompilationPlatformInfo platform)
+        {
+            return platform.CommonPlatformDefines.Contains(define)
+                || (inEditor ? platform.AdditionalInEditorDefines.Contains(define) : platform.AdditionalPlayerDefines.Contains(define));
+        }
+
+        private void FilterPlatformsBasedOnDefineConstraints(IDictionary<BuildTarget, CompilationPlatformInfo> platformDictionary, bool inEditor)
+        {
+            if (DefineConstraints.Count == 0)
+            {
+                // No exclusions
+                return;
+            }
+
+            bool defaultExcludeValue = DefineConstraints.Any(t => !t.StartsWith("!"));
+            HashSet<BuildTarget> toExclude = new HashSet<BuildTarget>();
+            foreach (KeyValuePair<BuildTarget, CompilationPlatformInfo> platformPair in platformDictionary)
+            {
+                // We presume exclude, then check
+                bool exclude = defaultExcludeValue;
+                foreach (string define in DefineConstraints)
+                {
+                    // Does this define exclude
+                    if (define.StartsWith("!"))
+                    {
+                        if (ContainsDefineHelper(define.Substring(1), inEditor, platformPair.Value))
+                        {
+                            exclude = true;
+                            break;
+                        }
+                    }
+                    else if (ContainsDefineHelper(define, inEditor, platformPair.Value))
+                    {
+                        // This platform is supported, but still search for !defineconstraitns that may force exclusion
+                        exclude = false;
+                    }
+                }
+
+                if (exclude)
+                {
+                    toExclude.Add(platformPair.Key);
+                }
+            }
+
+            foreach (BuildTarget buildTarget in toExclude)
+            {
+                platformDictionary.Remove(buildTarget);
+            }
+        }
+
+        private void TryAddEnabledPlatform(Dictionary<BuildTarget, CompilationPlatformInfo> playerPlatforms, Dictionary<string, bool> enabledPlatforms, string platformName, BuildTarget platformTarget)
+        {
+            if (enabledPlatforms.TryGetValue(platformName, out bool platformEnabled) && platformEnabled)
+            {
+                CompilationPlatformInfo platform = UnityProjectInfo.AvailablePlatforms.FirstOrDefault(t => t.BuildTarget == platformTarget);
+                if (platform != null)
+                {
+                    playerPlatforms.Add(platformTarget, platform);
+                }
+                else
+                {
+                    Debug.LogError($"Platform '{platformName}' was specified as enabled by '{ReferencePath.LocalPath}' plugin, but not available in processed compilation settings.");
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/WinMDInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/WinMDInfo.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 }
                 else
                 {
-                    // If it's not defineConstraints, then it's one of the other 3
+                    // If it's not defineConstraints, check next for platformData
                     platformData = defineConstraints;
                 }
 

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/WinMDInfo.cs.meta
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/WinMDInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 769306ff23e177f4abf9ce36414f8f44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Currently only managed plugins are referenced in MSBuildForUnity project generation. In some instances, we also need to include winmd references. This change introduces the concept of winmds and adds winmd references to MSBuildForUnity generated projects. 

https://github.com/microsoft/MSBuildForUnity/pull/93 is currently open and addresses all changes before 137fd4d "add winmd support"