### PR TITLE
Three Fixes: Unity.ugui Issue; NUnit meta parsing; 2019/2018 warning

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
@@ -163,9 +163,11 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             BuildTarget.StandaloneWindows,
             BuildTarget.StandaloneWindows64,
             BuildTarget.StandaloneOSX,
-            BuildTarget.StandaloneLinux,
             BuildTarget.StandaloneLinux64,
+#if UNITY_2018
+            BuildTarget.StandaloneLinux,
             BuildTarget.StandaloneLinuxUniversal,
+#endif
             BuildTarget.iOS,
             BuildTarget.Android,
             BuildTarget.WSAPlayer

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
@@ -158,19 +158,19 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             }
         }
 
-        private static readonly HashSet<BuildTarget> supportedBuildTargets = new HashSet<BuildTarget>()
+        public static readonly Dictionary<BuildTarget, string> SupportedBuildTargets = new Dictionary<BuildTarget, string>()
         {
-            BuildTarget.StandaloneWindows,
-            BuildTarget.StandaloneWindows64,
-            BuildTarget.StandaloneOSX,
-            BuildTarget.StandaloneLinux64,
+            { BuildTarget.StandaloneWindows, "Win" },
+            { BuildTarget.StandaloneWindows64, "Win64" },
+            { BuildTarget.StandaloneOSX, "OSXUniversal" },
+            { BuildTarget.StandaloneLinux64, "Linux64" },
 #if UNITY_2018
-            BuildTarget.StandaloneLinux,
-            BuildTarget.StandaloneLinuxUniversal,
+            { BuildTarget.StandaloneLinux, "Linux" },
+            { BuildTarget.StandaloneLinuxUniversal, "LinuxUniversal" },
 #endif
-            BuildTarget.iOS,
-            BuildTarget.Android,
-            BuildTarget.WSAPlayer
+            { BuildTarget.iOS, "iOS" },
+            { BuildTarget.Android, "Android" },
+            { BuildTarget.WSAPlayer, "WindowsStoreApps" }
         };
 
         public const string CSharpVersion = "7.3";
@@ -181,7 +181,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
 
         private static UnityProjectInfo unityProjectInfo;
 
-        public static UnityProjectInfo UnityProjectInfo => unityProjectInfo ?? (unityProjectInfo = new UnityProjectInfo(supportedBuildTargets, Config));
+        public static UnityProjectInfo UnityProjectInfo => unityProjectInfo ?? (unityProjectInfo = new UnityProjectInfo(SupportedBuildTargets, Config));
 
         private static IProjectExporter exporter = null;
 
@@ -232,7 +232,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
 
         public static void RegenerateSDKProjects()
         {
-            RegenerateEverything(reparseUnityData:true);
+            RegenerateEverything(reparseUnityData: true);
             Debug.Log($"{nameof(RegenerateSDKProjects)} Completed Succesfully.");
         }
 
@@ -277,7 +277,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             bool shouldClean = EditorPrefs.GetInt($"{nameof(MSBuildTools)}.{nameof(currentBuildTarget)}") != (int)currentBuildTarget
                 || EditorPrefs.GetInt($"{nameof(MSBuildTools)}.{nameof(targetFramework)}") != (int)targetFramework
                 || forceGenerateEverything;
-                        
+
             if (shouldClean)
             {
                 // We clean up previous build if the EditorPrefs currentBuildTarget or targetFramework is different from current ones.

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/PluginAssemblyInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/PluginAssemblyInfo.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                     {
                         // No define constraints
                     }
-                    else if (match.Success) // We have non-empty string in teh contents of the group we matched; NUnit has this:  defineConstraints: ["UNITY_INCLUDE_TESTS"]
+                    else if (match.Success) // We have non-empty string in the contents of the group we matched; NUnit has this:  defineConstraints: ["UNITY_INCLUDE_TESTS"]
                     {
                         // Yaml kinda allows this
                         string[] defines = match.Groups[1].Value.Trim().Split(',');

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
@@ -221,8 +221,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 }
             }
 
-            // Now we have all of the assembly definiton files, let's run a quick validation on the references to correct known errors like "unity.ugui" supposed to be "UnityEngine.UI"
-            /// <see cref="ProjectAliases"/> for the correction map.
+            // Now we have all of the assembly definiton files, let's run a quick validation. 
             CorrectReferences(asmDefInfoMap);
 
             int index = 0;
@@ -241,6 +240,9 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             return projectsMap;
         }
 
+        /// <summary>
+        /// This performs reference correction, for example this corrects "Unity.ugui" to be "UnityEngine.UI" (a known error of TextMeshPro). For correction map see <see cref="ProjectAliases"/>.
+        /// </summary>
         private void CorrectReferences(Dictionary<string, AssemblyDefinitionInfo> asmDefInfoMap)
         {
             foreach (KeyValuePair<string, AssemblyDefinitionInfo> asmDefPair in asmDefInfoMap)

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
@@ -27,6 +27,14 @@ namespace Microsoft.Build.Unity.ProjectGeneration
         };
 
         /// <summary>
+        /// For some Unity packages, references don't match the appropriate asmdef name.
+        /// </summary>
+        private static readonly Dictionary<string, string> ProjectAliases = new Dictionary<string, string>()
+        {
+            { "Unity.ugui", "UnityEngine.UI" }
+        };
+
+        /// <summary>
         /// Gets the name of this Unity Project.
         /// </summary>
         public string UnityProjectName { get; }
@@ -61,11 +69,11 @@ namespace Microsoft.Build.Unity.ProjectGeneration
         /// </summary>
         public IReadOnlyCollection<WinMDInfo> WinMDs { get; private set; }
 
-        public UnityProjectInfo(HashSet<BuildTarget> supportedBuildTargets, MSBuildToolsConfig config)
+        public UnityProjectInfo(Dictionary<BuildTarget, string> supportedBuildTargets, MSBuildToolsConfig config)
         {
             AvailablePlatforms = new ReadOnlyCollection<CompilationPlatformInfo>(CompilationPipeline.GetAssemblyDefinitionPlatforms()
                     .Where(t => Utilities.IsPlatformInstalled(t.BuildTarget))
-                    .Where(t => supportedBuildTargets.Contains(t.BuildTarget))
+                    .Where(t => supportedBuildTargets.ContainsKey(t.BuildTarget))
                     .Select(CompilationPlatformInfo.GetCompilationPlatform)
                     .OrderBy(t => t.Name).ToList());
 
@@ -213,6 +221,10 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 }
             }
 
+            // Now we have all of the assembly definiton files, let's run a quick validation on the references to correct known errors like "unity.ugui" supposed to be "UnityEngine.UI"
+            /// <see cref="ProjectAliases"/> for the correction map.
+            CorrectReferences(asmDefInfoMap);
+
             int index = 0;
             ProcessSortedAsmDef(asmDefDirectoriesSorted.ToArray(), ref index, (uri) => true, (a) => { });
 
@@ -227,6 +239,25 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             }
 
             return projectsMap;
+        }
+
+        private void CorrectReferences(Dictionary<string, AssemblyDefinitionInfo> asmDefInfoMap)
+        {
+            foreach (KeyValuePair<string, AssemblyDefinitionInfo> asmDefPair in asmDefInfoMap)
+            {
+                for (int i = 0; i < asmDefPair.Value.References.Length; i++)
+                {
+                    string reference = asmDefPair.Value.References[i];
+                    if (!asmDefInfoMap.ContainsKey(reference))
+                    {
+                        if (ProjectAliases.TryGetValue(reference, out string correctedReference))
+                        {
+                            Debug.Log($"Correcting package '{reference}' to '{correctedReference}'.");
+                            asmDefPair.Value.References[i] = correctedReference;
+                        }
+                    }
+                }
+            }
         }
 
         private void ProcessSortedAsmDef(AssemblyDefinitionInfo[] set, ref int currentIndex, Func<Uri, bool> childOfParentFunc, Action<AssemblyDefinitionInfo> addAsChild)


### PR DESCRIPTION
This PR contains three fixes:
- Remap Unity.ugui in a similar fashion (but different point) as #98 
- Correct meta parsing for "All" platforms included
- Correct meta parsing for NUnit.framework.dll.meta that species "DefineConstraint" in a strange way
- Fix a 2019 Warning on platform

Fixes #97.