### PR TITLE
Ensure MSBuild directory exists when the settings file is being written

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
@@ -84,6 +84,8 @@ namespace Microsoft.Build.Unity.ProjectGeneration
 
         private void Save()
         {
+            // Ensure directory exists first
+            Directory.CreateDirectory(Path.GetDirectoryName(MSBuildSettingsFilePath));
             File.WriteAllText(MSBuildSettingsFilePath, EditorJsonUtility.ToJson(this));
         }
 


### PR DESCRIPTION
When MSB4U is added to a brand new project, there will be a an exception thrown when settings.json file is being written because the MSBuild directory doesn't exist. So, just call CreateDirectory which will go ahead and create all directories an subdirectories in a given path (unless they exist).