### PR TITLE
Added Special Patching of TestRunner

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/AssemblyDefinitionInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/AssemblyDefinitionInfo.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             toReturn.BuiltInPackage = isBuiltInPackage;
             toReturn.Validate(unityProjectInfo.AvailablePlatforms);
             toReturn.PrecompiledAssemblyReferences = new HashSet<string>(toReturn.precompiledReferences?.Select(t => t.Replace(".dll", string.Empty)) ?? Array.Empty<string>());
+            toReturn.DefineConstraints = new HashSet<string>(toReturn.defineConstraints ?? (toReturn.defineConstraints = new string[0]));
             return toReturn;
         }
 
@@ -90,7 +91,9 @@ namespace Microsoft.Build.Unity.ProjectGeneration
         [SerializeField]
         private string[] precompiledReferences = null;
         public bool autoReferenced;
-        public string[] defineConstraints;
+
+        [SerializeField]
+        private string[] defineConstraints = null;
 
         /// <summary>
         /// Gets or sets the parsed Guid of the AssemblyDefinition asset.
@@ -147,7 +150,15 @@ namespace Microsoft.Build.Unity.ProjectGeneration
         /// </summary>
         public HashSet<string> PrecompiledAssemblyReferences { get; private set; }
 
+        /// <summary>
+        /// Gets assembly defintions that are nested (in terms of folder hierarchy) in respect to this assembly defintion.
+        /// </summary>
         public HashSet<AssemblyDefinitionInfo> NestedAssemblyDefinitionFiles { get; } = new HashSet<AssemblyDefinitionInfo>();
+
+        /// <summary>
+        /// Gets the define constraints for this assembly defintion.
+        /// </summary>
+        public HashSet<string> DefineConstraints { get; private set; }
 
         /// <summary>
         /// After it's parsed from JSON, this method should be invoked to validate some of the values and set additional properties.

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Exporters/TemplatedProjectExporter.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Exporters/TemplatedProjectExporter.cs
@@ -413,6 +413,9 @@ namespace Microsoft.Build.Unity.ProjectGeneration.Exporters
                 }
             }
 
+            List<string> availablePlatformsNames = unityProjectInfo.AvailablePlatforms.Select(t => t.Name).ToList();
+            Dictionary<string, List<string>> defaultPlatformsMap = new Dictionary<string, List<string>> { { "InEditor", availablePlatformsNames }, { "Player", availablePlatformsNames } };
+
             // Iterate over every project
             foreach (CSProjectInfo project in orderedProjects)
             {
@@ -442,7 +445,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration.Exporters
                 ProcessProjectPlatforms("Player", enabledPlayerPlatforms);
 
                 // Add all other known solution mappings, map to itself or allowed mappings
-                ProcessDefaultMappings(mapping, new Dictionary<string, List<string>> { { "InEditor", enabledInEditorPlatforms }, { "Player", enabledPlayerPlatforms } });
+                ProcessDefaultMappings(mapping, defaultPlatformsMap);
             }
 
             // Process the Dependencies Project now

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Exporters/TemplatedProjectExporter.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Exporters/TemplatedProjectExporter.cs
@@ -413,8 +413,8 @@ namespace Microsoft.Build.Unity.ProjectGeneration.Exporters
                 }
             }
 
-            List<string> availablePlatformsNames = unityProjectInfo.AvailablePlatforms.Select(t => t.Name).ToList();
-            Dictionary<string, List<string>> defaultPlatformsMap = new Dictionary<string, List<string>> { { "InEditor", availablePlatformsNames }, { "Player", availablePlatformsNames } };
+            List<string> availablePlatformNames = unityProjectInfo.AvailablePlatforms.Select(t => t.Name).ToList();
+            Dictionary<string, List<string>> defaultPlatformsMap = new Dictionary<string, List<string>> { { "InEditor", availablePlatformNames }, { "Player", availablePlatformNames } };
 
             // Iterate over every project
             foreach (CSProjectInfo project in orderedProjects)

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
@@ -35,6 +35,16 @@ namespace Microsoft.Build.Unity.ProjectGeneration
         };
 
         /// <summary>
+        /// Another patching technique to add defines to some assembly defintion file. TestRunner for example, is only referenced by projects with UNITY_INCLUDE_TESTS and references nunit that has UNITY_INCLUDE_TESTS;
+        /// However it doesn't have the define itself. This breaks Player build, and as it appears that Unity specially handles this case as well.
+        /// </summary>
+        private static readonly Dictionary<string, List<string>> ImpledDefinesForAsmDefs = new Dictionary<string, List<string>>()
+        {
+            { "UnityEditor.TestRunner", new List<string>(){ "UNITY_INCLUDE_TESTS" } },
+            { "UnityEngine.TestRunner", new List<string>(){ "UNITY_INCLUDE_TESTS" } },
+        };
+
+        /// <summary>
         /// Gets the name of this Unity Project.
         /// </summary>
         public string UnityProjectName { get; }
@@ -257,6 +267,14 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                             Debug.Log($"Correcting package '{reference}' to '{correctedReference}'.");
                             asmDefPair.Value.References[i] = correctedReference;
                         }
+                    }
+                }
+
+                if (ImpledDefinesForAsmDefs.TryGetValue(asmDefPair.Key, out List<string> defines))
+                {
+                    foreach (string define in defines)
+                    {
+                        asmDefPair.Value.DefineConstraints.Add(define);
                     }
                 }
             }

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/UnityProjectInfo.cs
@@ -35,10 +35,10 @@ namespace Microsoft.Build.Unity.ProjectGeneration
         };
 
         /// <summary>
-        /// Another patching technique to add defines to some assembly defintion file. TestRunner for example, is only referenced by projects with UNITY_INCLUDE_TESTS and references nunit that has UNITY_INCLUDE_TESTS;
+        /// Another patching technique to add defines to some assembly defintion files. TestRunner for example, is only referenced by projects with UNITY_INCLUDE_TESTS and references nunit that has UNITY_INCLUDE_TESTS;
         /// However it doesn't have the define itself. This breaks Player build, and as it appears that Unity specially handles this case as well.
         /// </summary>
-        private static readonly Dictionary<string, List<string>> ImpledDefinesForAsmDefs = new Dictionary<string, List<string>>()
+        private static readonly Dictionary<string, List<string>> ImpliedDefinesForAsmDefs = new Dictionary<string, List<string>>()
         {
             { "UnityEditor.TestRunner", new List<string>(){ "UNITY_INCLUDE_TESTS" } },
             { "UnityEngine.TestRunner", new List<string>(){ "UNITY_INCLUDE_TESTS" } },
@@ -232,7 +232,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
             }
 
             // Now we have all of the assembly definiton files, let's run a quick validation. 
-            CorrectReferences(asmDefInfoMap);
+            ValidateAndPatchAssemblyDefinitions(asmDefInfoMap);
 
             int index = 0;
             ProcessSortedAsmDef(asmDefDirectoriesSorted.ToArray(), ref index, (uri) => true, (a) => { });
@@ -253,7 +253,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
         /// <summary>
         /// This performs reference correction, for example this corrects "Unity.ugui" to be "UnityEngine.UI" (a known error of TextMeshPro). For correction map see <see cref="ProjectAliases"/>.
         /// </summary>
-        private void CorrectReferences(Dictionary<string, AssemblyDefinitionInfo> asmDefInfoMap)
+        private void ValidateAndPatchAssemblyDefinitions(Dictionary<string, AssemblyDefinitionInfo> asmDefInfoMap)
         {
             foreach (KeyValuePair<string, AssemblyDefinitionInfo> asmDefPair in asmDefInfoMap)
             {
@@ -270,7 +270,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                     }
                 }
 
-                if (ImpledDefinesForAsmDefs.TryGetValue(asmDefPair.Key, out List<string> defines))
+                if (ImpliedDefinesForAsmDefs.TryGetValue(asmDefPair.Key, out List<string> defines))
                 {
                     foreach (string define in defines)
                     {


### PR DESCRIPTION
TestRunner is a strange asmdef, so added special patching for this project. The AsmDef is referenced by Test projects that always have 'UNITY_INCLUDE_TESTS' defined, and it references nunit which also has it set. However, it itself doesn't and this breaks during generated projects player compilation as no player platform includes that define.