### PR TITLE
Fix Dependency name in Generated Solution File

### DIFF
--- a/Samples/CrossUnityDependencies.Unity/Assets/CrossUnityDependencies.Unity.msb4u.sln
+++ b/Samples/CrossUnityDependencies.Unity/Assets/CrossUnityDependencies.Unity.msb4u.sln
@@ -27,7 +27,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Assembly-CSharp.msb4u", "As
 		{0FDA7EBE-61AB-2164-383D-10E32EFB9C6E} = {0FDA7EBE-61AB-2164-383D-10E32EFB9C6E}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dependencies.msb4u", "Dependencies.msb4u.csproj", "{F462FC4F-630C-4212-83AE-9208D85AD084}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CrossUnityDependencies.Unity.Dependencies.msb4u", "CrossUnityDependencies.Unity.Dependencies.msb4u.csproj", "{F462FC4F-630C-4212-83AE-9208D85AD084}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeneralComponent.msb4u", "..\..\IntegratedDependencies.Unity\Assets\GeneralComponent\GeneralComponent.msb4u.csproj", "{C47857AB-4B18-4AED-94F8-E6ACB45B6484}"
 EndProject

--- a/Samples/IntegratedDependencies.Unity/Assets/Project.Unity.msb4u.sln
+++ b/Samples/IntegratedDependencies.Unity/Assets/Project.Unity.msb4u.sln
@@ -2,6 +2,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28307.539
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Component.WSA.msb4u", "WSASpecific\Component.WSA.msb4u.csproj", "{BB41A40A-FD6B-AD74-0865-83AB52977BDC}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeneralComponent.msb4u", "GeneralComponent\GeneralComponent.msb4u.csproj", "{CE0A9636-8BD6-E674-193B-98C6048CB6BD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unity.TextMeshPro.msb4u", "..\MSBuild\Projects\Unity.TextMeshPro.msb4u.csproj", "{6055BE8E-BEFD-69E4-8B49-212B09B47B2F}"
@@ -25,12 +27,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Assembly-CSharp.msb4u", "As
 		{6546D776-5B41-65B4-0850-B3667F981C26} = {6546D776-5B41-65B4-0850-B3667F981C26}
 		{15A615C7-33AA-2409-09FE-0B28B0D5143C} = {15A615C7-33AA-2409-09FE-0B28B0D5143C}
 		{645165C8-1694-74BF-BBEB-8FB0BCFD26F5} = {645165C8-1694-74BF-BBEB-8FB0BCFD26F5}
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC} = {BB41A40A-FD6B-AD74-0865-83AB52977BDC}
 		{0DF1F49A-50F1-5354-5BF9-9E3DBB6674AD} = {0DF1F49A-50F1-5354-5BF9-9E3DBB6674AD}
 		{6055BE8E-BEFD-69E4-8B49-212B09B47B2F} = {6055BE8E-BEFD-69E4-8B49-212B09B47B2F}
 		{0FDA7EBE-61AB-2164-383D-10E32EFB9C6E} = {0FDA7EBE-61AB-2164-383D-10E32EFB9C6E}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dependencies.msb4u", "Dependencies.msb4u.csproj", "{0D77AB82-D4EB-4034-AC54-4CA04D06906C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Project.Unity.Dependencies.msb4u", "Project.Unity.Dependencies.msb4u.csproj", "{0D77AB82-D4EB-4034-AC54-4CA04D06906C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonLibrary", "..\External\CommonLibrary\CommonLibrary.csproj", "{D36DD91A-2347-4BE3-BDAD-E72898C014BA}"
 EndProject
@@ -70,6 +73,36 @@ Global
 		Release|WSA = Release|WSA
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Debug|Android.ActiveCfg = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Debug|Any CPU.ActiveCfg = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Debug|iOS.ActiveCfg = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Debug|WindowsStandalone32.ActiveCfg = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Debug|WindowsStandalone64.ActiveCfg = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Debug|WSA.ActiveCfg = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.InEditor|Android.ActiveCfg = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.InEditor|Android.Build.0 = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.InEditor|Any CPU.ActiveCfg = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.InEditor|iOS.ActiveCfg = InEditor|iOS
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.InEditor|iOS.Build.0 = InEditor|iOS
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.InEditor|WindowsStandalone32.ActiveCfg = InEditor|WindowsStandalone32
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.InEditor|WindowsStandalone32.Build.0 = InEditor|WindowsStandalone32
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.InEditor|WindowsStandalone64.ActiveCfg = InEditor|WindowsStandalone64
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.InEditor|WindowsStandalone64.Build.0 = InEditor|WindowsStandalone64
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.InEditor|WSA.ActiveCfg = InEditor|WSA
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.InEditor|WSA.Build.0 = InEditor|WSA
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Player|Android.ActiveCfg = Player|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Player|Any CPU.ActiveCfg = Player|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Player|iOS.ActiveCfg = Player|iOS
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Player|WindowsStandalone32.ActiveCfg = Player|WindowsStandalone32
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Player|WindowsStandalone64.ActiveCfg = Player|WindowsStandalone64
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Player|WSA.ActiveCfg = Player|WSA
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Player|WSA.Build.0 = Player|WSA
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Release|Android.ActiveCfg = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Release|Any CPU.ActiveCfg = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Release|iOS.ActiveCfg = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Release|WindowsStandalone32.ActiveCfg = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Release|WindowsStandalone64.ActiveCfg = InEditor|Android
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC}.Release|WSA.ActiveCfg = InEditor|Android
 		{CE0A9636-8BD6-E674-193B-98C6048CB6BD}.Debug|Android.ActiveCfg = InEditor|Android
 		{CE0A9636-8BD6-E674-193B-98C6048CB6BD}.Debug|Any CPU.ActiveCfg = InEditor|Android
 		{CE0A9636-8BD6-E674-193B-98C6048CB6BD}.Debug|iOS.ActiveCfg = InEditor|Android
@@ -464,6 +497,7 @@ Global
 	GlobalSection(SolutionNotes) = postSolution
 		{F0962E2E-3201-42A4-90A4-4BD07B8D0413} = msb4u.generated
 		{02CFE9B1-8003-483F-802B-F2ACC2E2C82B} = msb4u.generated
+		{BB41A40A-FD6B-AD74-0865-83AB52977BDC} = msb4u.generated
 		{CE0A9636-8BD6-E674-193B-98C6048CB6BD} = msb4u.generated
 		{6055BE8E-BEFD-69E4-8B49-212B09B47B2F} = msb4u.generated
 		{15A615C7-33AA-2409-09FE-0B28B0D5143C} = msb4u.generated

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/MSBuildForUnity.Common.props.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/MSBuildForUnity.Common.props.template
@@ -29,9 +29,11 @@
     <_MSB4UPropagateProperties>MSBuildForUnityVersion=$(MSBuildForUnityVersion);MSBuildForUnityPlatformPropsDirectory=$(MSBuildForUnityPlatformPropsDirectory);MSBuildForUnityBuildOutputDirectory=$(MSBuildForUnityBuildOutputDirectory);MSBuildForUnityPublishDirectory=$(MSBuildForUnityPublishDirectory);MSBuildForUnityDefaultOutputPath=$(MSBuildForUnityDefaultOutputPath);UnityCurrentPlatform=$(UnityCurrentPlatform);UnityCurrentTargetFramework=$(UnityCurrentTargetFramework);UnityMajorVersion=$(UnityMajorVersion);UnityMinorVersion=$(UnityMinorVersion);</_MSB4UPropagateProperties>
   </PropertyGroup>
   
+<!-- Disabling Clean; brief testing showed there wasn't any errors. If errors are encountered, this should be re-enabled.
   <Target Name="_RemoveOutputDirectory" AfterTargets="Clean">
     <RemoveDir Directories="$(OutputPath)"/>
   </Target>
+-->
   
   <Target Name="_PropagateMSB4UProperties">
     <ItemGroup>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Exporters/TemplatedExporter/TemplatedUnityProjectExporter.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Exporters/TemplatedExporter/TemplatedUnityProjectExporter.cs
@@ -580,7 +580,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration.Exporters.TemplatedExporter
 
             // Add the "Dependencies" project
             {
-                string dependencyRelativePath = Utilities.GetRelativePath(Path.GetDirectoryName(solutionFilePath), GetProjectFilePath(Utilities.AssetPath, "Dependencies"));
+                string dependencyRelativePath = Utilities.GetRelativePath(Path.GetDirectoryName(solutionFilePath), GetProjectFilePath(Utilities.AssetPath, $"{unityProjectInfo.UnityProjectName}.Dependencies"));
                 IEnumerable<SolutionFileSection<SolutionProjecSectionType>> extraSections = null;
 
                 if (solutionFileInfo != null)
@@ -591,7 +591,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration.Exporters.TemplatedExporter
                         extraSections = existingProject.Sections.Values;
                     }
                 }
-                ProcessProjectEntry("Dependencies.msb4u", dependencyRelativePath, config.DependenciesProjectGuid, null, projectTemplate, projectTemplate.CreateReplacementSet(rootReplacementSet), extraSections);
+                ProcessProjectEntry($"{unityProjectInfo.UnityProjectName}.Dependencies.msb4u", dependencyRelativePath, config.DependenciesProjectGuid, null, projectTemplate, projectTemplate.CreateReplacementSet(rootReplacementSet), extraSections);
             }
 
             if (solutionFileInfo != null)


### PR DESCRIPTION
This is a fix on top of previous change for the Dependency project rename, to also make sure we rename it in the generated solution file.

This change also disabled the "CleanupTask" that performed a deletes in the output directory. This causes no errors thus far, and if it does it will be re-enabled; otherwise this will be removed and the issue #71 can be closed.