### PR TITLE
New dotnet SDK support

### DIFF
--- a/Source/MSBuildTools.Unity.NuGet/Publish.props
+++ b/Source/MSBuildTools.Unity.NuGet/Publish.props
@@ -7,9 +7,6 @@
   <PropertyGroup>
     <!-- This causes the full dependency graph (from ProjectReferences and PackageReferences) to be copied to the build output directory. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-
-    <!-- This causes generation of a XML documentation file based on comments in the source code. -->
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/MSBuildTools.Unity.NuGet/Publish.props
+++ b/Source/MSBuildTools.Unity.NuGet/Publish.props
@@ -7,6 +7,9 @@
   <PropertyGroup>
     <!-- This causes the full dependency graph (from ProjectReferences and PackageReferences) to be copied to the build output directory. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+
+    <!-- This causes generation of a XML documentation file based on comments in the source code. -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/MSBuildTools.Unity.NuGet/Publish.targets
+++ b/Source/MSBuildTools.Unity.NuGet/Publish.targets
@@ -4,19 +4,19 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <!-- This target filters the @(AllCopyLocalItems) item list based on the provided publish file exclusion list. -->
-  <Target Name="FilterCopyLocal" DependsOnTargets="PrepareForBuild" BeforeTargets="ResolveLockFileCopyLocalProjectDeps" Condition=" '@(NuGetPackageIdExclusionList)' != '' ">
+  <!-- This target filters the @(ReferenceCopyLocalPaths) item list based on the provided publish file exclusion list. -->
+  <Target Name="_FilterReferenceCopyLocalPaths" AfterTargets="ResolveAssemblyReferences" Condition=" '@(NuGetPackageIdExclusionList)' != '' ">
     <ItemGroup>
-      <!-- This duplicates each item in @(AllCopyLocalItems), once per item in @(NuGetPackageIdExclusionList). -->
-      <AllCopyLocalItemsWithExclusionListMetadata Include="@(AllCopyLocalItems)">
+      <!-- This duplicates each item in @(ReferenceCopyLocalPaths), once per item in @(NuGetPackageIdExclusionList). -->
+      <_AllReferenceCopyLocalPathsWithExclusionListMetadata Include="@(ReferenceCopyLocalPaths)">
         <NuGetPackageIdExclusionList>%(NuGetPackageIdExclusionList.Identity)</NuGetPackageIdExclusionList>
-      </AllCopyLocalItemsWithExclusionListMetadata>
+      </_AllReferenceCopyLocalPathsWithExclusionListMetadata>
 
-      <!-- This filters the list back down to just the items where the NuGetPackageId matches one of the items in NuGetPackageIdExclusionList (e.g. the excluded items of @(AllCopyLocalItems)). -->
-      <ExcludedAllCopyLocalItems Include="@(AllCopyLocalItemsWithExclusionListMetadata)" Condition=" '%(AllCopyLocalItemsWithExclusionListMetadata.NuGetPackageId)' == '%(AllCopyLocalItemsWithExclusionListMetadata.NuGetPackageIdExclusionList)' " />
+      <!-- This filters the list back down to just the items where the NuGetPackageId matches one of the items in NuGetPackageIdExclusionList (e.g. the excluded items of @(ReferenceCopyLocalPaths)). -->
+      <ExcludedAllReferenceCopyLocalPaths Include="@(_AllReferenceCopyLocalPathsWithExclusionListMetadata)" Condition=" '%(_AllReferenceCopyLocalPathsWithExclusionListMetadata.NuGetPackageId)' == '%(_AllReferenceCopyLocalPathsWithExclusionListMetadata.NuGetPackageIdExclusionList)' " />
 
       <!-- Finally, actually remove the items that have been identified as excluded. -->
-      <AllCopyLocalItems Remove="@(ExcludedAllCopyLocalItems)" />
+      <ReferenceCopyLocalPaths Remove="@(ExcludedAllReferenceCopyLocalPaths)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Updating the package filtering to use a different group later in the process.  This is supported in both dotnet SDK 2 (the old one) and 3 (the new one), whereas the old target and group went away in 3.