### PR TITLE
Added NuGet.config to TemplateFiles

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/NuGet.config
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <add key="MSBuildForUnity" value="https://pkgs.dev.azure.com/UnityDeveloperTools/MSBuildForUnity/_packaging/UnityDeveloperTools/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/NuGet.config
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/NuGet.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <add key="MSBuildForUnity" value="https://pkgs.dev.azure.com/UnityDeveloperTools/MSBuildForUnity/_packaging/UnityDeveloperTools/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/NuGet.config.meta
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/NuGet.config.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: 32cacb4435d9edb4fbd83f140ee4cf6f
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
@@ -380,8 +380,14 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 MSBuildUnityProjectExporter.ExportTopLevelDependenciesProject(Exporter, Config, new DirectoryInfo(Utilities.MSBuildProjectFolder), unityProjectInfo);
                 solutionExportEnd = stopwatch.ElapsedMilliseconds;
 
-                // Copy the NuGet.config file
-                File.Copy(TemplateFiles.Instance.NuGetConfigPath, Path.Combine(Utilities.AssetPath, Path.GetFileName(TemplateFiles.Instance.NuGetConfigPath)));
+
+                string nuGetConfigPath = Path.Combine(Utilities.AssetPath, Path.GetFileName(TemplateFiles.Instance.NuGetConfigPath));
+                
+                // Copy the NuGet.config file if it does not exist
+                if (!File.Exists(nuGetConfigPath))
+                {
+                    File.Copy(TemplateFiles.Instance.NuGetConfigPath, nuGetConfigPath);
+                }
 
                 foreach (string otherFile in TemplateFiles.Instance.OtherFiles)
                 {

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
@@ -380,9 +380,12 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 MSBuildUnityProjectExporter.ExportTopLevelDependenciesProject(Exporter, Config, new DirectoryInfo(Utilities.MSBuildProjectFolder), unityProjectInfo);
                 solutionExportEnd = stopwatch.ElapsedMilliseconds;
 
+                // Copy the NuGet.config file
+                File.Copy(TemplateFiles.Instance.NuGetConfigPath, Path.Combine(Utilities.AssetPath, Path.GetFileName(TemplateFiles.Instance.NuGetConfigPath)));
+
                 foreach (string otherFile in TemplateFiles.Instance.OtherFiles)
                 {
-                    File.Copy(otherFile, Path.Combine(Utilities.AssetPath, Path.GetFileName(otherFile)));
+                    File.Copy(otherFile, Path.Combine(Utilities.MSBuildProjectFolder, Path.GetFileName(otherFile)));
                 }
 
                 if (completeGeneration)

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
 
                 foreach (string otherFile in TemplateFiles.Instance.OtherFiles)
                 {
-                    File.Copy(otherFile, Path.Combine(Utilities.MSBuildProjectFolder, Path.GetFileName(otherFile)));
+                    File.Copy(otherFile, Path.Combine(Utilities.AssetPath, Path.GetFileName(otherFile)));
                 }
 
                 if (completeGeneration)

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Templates/TemplateFiles.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Templates/TemplateFiles.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration.Templates
         private const string SpecifcPlatformPropsTemplateRegex = @"[a-zA-Z]+\.[a-zA-Z]+\.[a-zA-Z0-9]*\.props.template";
         private const string PluginMetaFileTemplateRegex = @"Plugin\.([a-zA-Z]*)\.meta.template";
         private const string BuildProjectsTemplateName = "BuildProjects.proj.template";
-        private const string NugetConfigFileName = "NuGet.config";
+        private const string NuGetConfigFileName = "NuGet.config";
 
         private static TemplateFiles instance;
 
@@ -98,6 +98,11 @@ namespace Microsoft.Build.Unity.ProjectGeneration.Templates
         public string BuildProjectsTemplatePath { get; }
 
         /// <summary>
+        /// Gets the NuGet.config MSBuild file path.
+        /// </summary>
+        public string NuGetConfigPath { get; }
+
+        /// <summary>
         /// Gets a list of specialized platform templates.
         /// </summary>
         public IReadOnlyDictionary<string, FileInfo> PlatformTemplates { get; }
@@ -142,6 +147,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration.Templates
             SDKProjectTargetsFileTemplatePath = new FileInfo(GetExpectedTemplatesPath(fileNamesMaps, "SDK Project Targets", SDKProjectTargetsFileTemplateName));
             PlatformPropsTemplatePath = new FileInfo(GetExpectedTemplatesPath(fileNamesMaps, "Platform Props", PlatformPropsTemplateName));
             BuildProjectsTemplatePath = GetExpectedTemplatesPath(fileNamesMaps, "MSBuild Build Projects Proj", BuildProjectsTemplateName);
+            NuGetConfigPath = GetExpectedTemplatesPath(fileNamesMaps, "MSBuild NuGet.config", NuGetConfigFileName);
 
             // Get specific platforms
             Dictionary<string, FileInfo> platformTemplates = new Dictionary<string, FileInfo>();

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Templates/TemplateFiles.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Templates/TemplateFiles.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration.Templates
         private const string SpecifcPlatformPropsTemplateRegex = @"[a-zA-Z]+\.[a-zA-Z]+\.[a-zA-Z0-9]*\.props.template";
         private const string PluginMetaFileTemplateRegex = @"Plugin\.([a-zA-Z]*)\.meta.template";
         private const string BuildProjectsTemplateName = "BuildProjects.proj.template";
+        private const string NugetConfigFileName = "NuGet.config";
 
         private static TemplateFiles instance;
 


### PR DESCRIPTION
## Overview
While retrieving the MRTK NuGet packages via MSBuildForUnity, you first need to add ```https://pkgs.dev.azure.com/UnityDeveloperTools/MSBuildForUnity/_packaging/UnityDeveloperTools/nuget/v3/index.json ``` as a source.  This change removes adding an additional source to enable MRTK NuGet package installation with one step.

## Changes
- Added NuGet.config to TemplateFiles.cs
- Moved Nuget.config to the TemplateFiles directory

## Fixes
- #99 