### PR TITLE
Dependency Project Explicit Target Framework

### DIFF
--- a/Samples/CrossUnityDependencies.Unity/Assets/CrossUnityDependencies.Unity.Dependencies.msb4u.csproj
+++ b/Samples/CrossUnityDependencies.Unity/Assets/CrossUnityDependencies.Unity.Dependencies.msb4u.csproj
@@ -26,8 +26,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))')" />
 
   <PropertyGroup>
-    <!--anborod: This is a weird thing, it is a required property (even if commented)-->
-    <!--<TargetFrameworks>netstandard2.0;uap10.0;net46</TargetFrameworks> -->
+    <TargetFramework>$(UnityCurrentTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <!-- SDK.props is imported inside this props file -->

--- a/Samples/CrossUnityDependencies.Unity/README.md
+++ b/Samples/CrossUnityDependencies.Unity/README.md
@@ -52,8 +52,7 @@ In addition to that, the same line was added to the specific MSB4U project that 
   
   <Import Project="$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))')" />
   <PropertyGroup>
-    <!--anborod: This is a weird thing, it is a required property (even if commented)-->
-    <!--<TargetFrameworks>netstandard2.0;uap10.0;net46</TargetFrameworks> -->
+    <TargetFramework>$(UnityCurrentTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <!-- SDK.props is imported inside this props file -->

--- a/Samples/IntegratedDependencies.Unity/Assets/Project.Unity.Dependencies.msb4u.csproj
+++ b/Samples/IntegratedDependencies.Unity/Assets/Project.Unity.Dependencies.msb4u.csproj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="15.0">
+﻿<Project ToolsVersion="15.0">
   <!--GENERATED FILE-->
   <!--
     This file can be modified and checked in.
@@ -26,8 +26,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))')" />
 
   <PropertyGroup>
-    <!--anborod: This is a weird thing, it is a required property (even if commented)-->
-    <!--<TargetFrameworks>netstandard2.0;uap10.0;net46</TargetFrameworks> -->
+    <TargetFramework>$(UnityCurrentTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <!-- SDK.props is imported inside this props file -->

--- a/Samples/IntegratedDependencies.Unity/README.md
+++ b/Samples/IntegratedDependencies.Unity/README.md
@@ -53,8 +53,7 @@ In order to add dependencies to your project, you can open any C# project under 
   
   <Import Project="$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))')" />
   <PropertyGroup>
-    <!--anborod: This is a weird thing, it is a required property (even if commented)-->
-    <!--<TargetFrameworks>netstandard2.0;uap10.0;net46</TargetFrameworks> -->
+    <TargetFramework>$(UnityCurrentTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <Import Project="$(MSBuildForUnityGeneratedOutputDirectory)\$(MSBuildProjectName).g.props" />
@@ -102,8 +101,7 @@ The generated project `Assets/WSASpecific/Component.WSA.msb4u.csproj` contains a
   
   <Import Project="$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))')" />
   <PropertyGroup>
-    <!--anborod: This is a weird thing, it is a required property (even if commented)-->
-    <!--<TargetFrameworks>netstandard2.0;uap10.0;net46</TargetFrameworks> -->
+    <TargetFramework>$(UnityCurrentTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <Import Project="$(MSBuildForUnityGeneratedOutputDirectory)\$(MSBuildProjectName).g.props" />

--- a/Samples/SimpleNuGetDependency.Unity/Assets/Project.Unity.Dependencies.msb4u.csproj
+++ b/Samples/SimpleNuGetDependency.Unity/Assets/Project.Unity.Dependencies.msb4u.csproj
@@ -26,8 +26,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))')" />
 
   <PropertyGroup>
-    <!--anborod: This is a weird thing, it is a required property (even if commented)-->
-    <!--<TargetFrameworks>netstandard2.0;uap10.0;net46</TargetFrameworks> -->
+    <TargetFramework>$(UnityCurrentTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <!-- SDK.props is imported inside this props file -->

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/DependenciesProjectTemplate.csproj.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/DependenciesProjectTemplate.csproj.template
@@ -26,8 +26,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))')" />
 
   <PropertyGroup>
-    <!--anborod: This is a weird thing, it is a required property (even if commented)-->
-    <!--<TargetFrameworks>netstandard2.0;uap10.0;net46</TargetFrameworks> -->
+    <TargetFramework>$(UnityCurrentTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <!-- SDK.props is imported inside this props file -->

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/DependenciesProjectTemplate.g.props.template
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/DependenciesProjectTemplate.g.props.template
@@ -1,17 +1,6 @@
 <Project ToolsVersion="15.0">
-  <PropertyGroup Condition="'$(UnityCurrentTargetFramework)' == ''">
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(UnityCurrentTargetFramework)' != ''">
-    <TargetFramework>$(UnityCurrentTargetFramework)</TargetFramework>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(UnityCurrentPlatform)'!=''">
-    <UnityPlatform>$(UnityCurrentPlatform)</UnityPlatform>
-  </PropertyGroup>
-
   <PropertyGroup>
+	<UnityPlatform>$(UnityCurrentPlatform)</UnityPlatform>
     <ProjectGuid><!--PROJECT_GUID_TOKEN--></ProjectGuid>
     <UnityConfiguration>InEditor</UnityConfiguration>
     <!-- Make sure Unity ignores the contents of the intermediate output path. -->


### PR DESCRIPTION
In projects that are built for AsmDef, we don't know the target framework until we import the platform props, and that depends on the UnityConfig/UnityPlatform pairing we are building with.

For the top-level dependencies project we do, it's specifies in the common props file, so just set it immediately. This fixes an issue with VS2019.
