### PR TITLE
Upgrading version to 0.9.0

### DIFF
--- a/AzurePipelines/Publish.UPM.yml
+++ b/AzurePipelines/Publish.UPM.yml
@@ -16,7 +16,7 @@ pool:
 steps:
 - task: Npm@1
 # Only update the version on master branch
-  condition: not(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))
+  condition: and(not(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/prerelease/')))
   inputs:
     command: 'custom'
     customCommand: --no-git-tag-version version prerelease --preid=$(Build.BuildNumber)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,12 +11,12 @@
     <MSB4U_MinorVersion>9</MSB4U_MinorVersion>
     <MSB4U_RevisionVersion>0</MSB4U_RevisionVersion>
     <MSB4U_RevisionVersion_PreIncrement>$(MSB4U_RevisionVersion)</MSB4U_RevisionVersion_PreIncrement>
-    
-    <!-- If we are not on a release branch, we increment revision version -->
-    <MSB4U_RevisionVersion Condition="!$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/'))">$([MSBuild]::Add($(MSB4U_RevisionVersion), 1))</MSB4U_RevisionVersion>
+
+    <!-- If we are not on a release or prerelease branch, we increment the revision version -->
+    <MSB4U_RevisionVersion Condition="!$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/')) And !$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/prerelease/'))">$([MSBuild]::Add($(MSB4U_RevisionVersion), 1))</MSB4U_RevisionVersion>
     
     <MSB4U_Version>$(MSB4U_MajorVersion).$(MSB4U_MinorVersion).$(MSB4U_RevisionVersion)</MSB4U_Version>
-    <!-- Version is based on Major.Minor.Revision as defined above, however, in a lab BUILD_BUILDID will be set so we pull in that as the pre-release version. -->
+    <!-- Version is based on Major.Minor.Revision as defined above, however, in a lab BUILD_BUILDID will be set so we pull in that as the pre-release version for non-release branches only (but for prerelease branches we do pull it in). -->
     <MSB4U_Version Condition="'$(BUILD_BUILDID)' != '' And !$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/'))">$(MSB4U_Version)-$(BUILD_BUILDID)</MSB4U_Version>
 
     <MSB4U_PackageVersion>$(MSB4U_Version)</MSB4U_PackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,9 +8,9 @@
        - Revision (semver Patch) version is hard-coded and should be incremented when a bug fix is made.
     -->
     <MSB4U_MajorVersion>0</MSB4U_MajorVersion>
-    <MSB4U_MinorVersion>8</MSB4U_MinorVersion>
-    <MSB4U_RevisionVersion>3</MSB4U_RevisionVersion>
-    <MSB4U_RevisionVersion_PreIncrement>3</MSB4U_RevisionVersion_PreIncrement>
+    <MSB4U_MinorVersion>9</MSB4U_MinorVersion>
+    <MSB4U_RevisionVersion>0</MSB4U_RevisionVersion>
+    <MSB4U_RevisionVersion_PreIncrement>$(MSB4U_RevisionVersion)</MSB4U_RevisionVersion_PreIncrement>
     
     <!-- If we are not on a release branch, we increment revision version -->
     <MSB4U_RevisionVersion Condition="!$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/'))">$([MSBuild]::Add($(MSB4U_RevisionVersion), 1))</MSB4U_RevisionVersion>

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This scenario leverages the MSBuildForUnity [Project Builder](#msbuild-project-b
         Examples of how you can modify this file:
         - Add NuGet package references:
             <ItemGroup>
-            <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+                <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
             </ItemGroup>
         - Add external C# project references:
         <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -45,26 +45,56 @@ This scenario leverages the MSBuildForUnity [Project Builder](#msbuild-project-b
     - Add the following to the `dependencies` section of the file:
 
         ```json
-          "com.microsoft.msbuildforunity": "0.8.3"
+          "com.microsoft.msbuildforunity": "0.9.0"
         ```
 
-1. Create a "SDK style" MSBuild project (e.g. csproj) somewhere under your `Assets` directory of your Unity project that references the `MSBuildForUnity` NuGet package. Here is an example:
+1. MSBuildForUnity will create a top-level project in your `Assets` folder named after your Unity project name: `{UnityProjectName}.Dependencies.msb4u.csproj`, edit this project file to add additional references to any NuGet packages or C# projects you want to use in your Unity project.
 
     ```xml
-    <Project Sdk="Microsoft.NET.Sdk">
-        <PropertyGroup>
-            <TargetFramework>netstandard2.0</TargetFramework>
-        </PropertyGroup>
+    <Project ToolsVersion="15.0">
+    <!--GENERATED FILE-->
+    <!--
+        This file can be modified and checked in.
+        
+        It is different from the other generated C# Projects in that it will be the one gathering all dependencies and placing them into the Unity asset folder.
+        
+        You can add project level dependencies to this file, by placing them below:
+        - <Import Project="$(MSBuildForUnityGeneratedProjectDirectory)\$(MSBuildProjectName).g.props" />
+        and before:
+        - <Import Project="$(MSBuildForUnityGeneratedProjectDirectory)\$(MSBuildProjectName).g.targets" />
+        
+        Do not add any source or compilation items.
+        
+        Examples of how you can modify this file:
+        - Add NuGet package references:
+            <ItemGroup>
+            <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+            </ItemGroup>
+        - Add external C# project references:
         <ItemGroup>
-            <PackageReference Include="MSBuildForUnity" Version="0.8.3">
-                <PrivateAssets>all</PrivateAssets>
-                <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-            </PackageReference>
+            <ProjectReference Include="..\..\..\ExternalLib\ExternalLib.csproj" />
         </ItemGroup>
+    -->
+
+    <Import Project="$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))')" />
+
+    <PropertyGroup>
+        <TargetFramework>$(UnityCurrentTargetFramework)</TargetFramework>
+    </PropertyGroup>
+
+    <!-- SDK.props is imported inside this props file -->
+    <Import Project="$(MSBuildForUnityGeneratedProjectDirectory)\$(MSBuildProjectName).g.props" />
+
+    <ItemGroup>
+        <!--Add NuGet or Project references here-->
+    </ItemGroup>
+
+    <!-- SDK.targets is imported inside this props file -->
+    <Import Project="$(MSBuildForUnityGeneratedProjectDirectory)\$(MSBuildProjectName).g.targets" />
     </Project>
     ```
 
-1. Add additional references to any NuGet packages you want to use in your Unity project.
+1. For additional instructions, see [Core Scenarios](Documentation/CoreScenarios.md).
 
 ## Extended Instructions
 

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/MSBuildTools.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
         public const string CSharpVersion = "7.3";
         public const string FullGeneration = "MSBuild/Full Generation Enabled";
 
-        public static readonly Version MSBuildForUnityVersion = new Version(0, 8, 3);
+        public static readonly Version MSBuildForUnityVersion = new Version(0, 9, 0);
         public static readonly Version DefaultMinUWPSDK = new Version("10.0.14393.0");
 
         private static UnityProjectInfo unityProjectInfo;

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/package.json
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/package.json
@@ -1,26 +1,25 @@
 {
     "name": "com.microsoft.msbuildforunity",
-    "version": "0.8.3",
+    "version": "0.9.0",
     "displayName": "MSBuild for Unity",
     "description": "MSBuildForUnity solves the problem of establishing clear dependency relationships between Unity project and other .NET components such as external (to Unity) C# projects, or NuGet packages. It creates a familiar to .NET developers project structure and ensures that the dependencies are resolved and brought into the Unity project as appropriate.",
     "unity": "2018.1",
-    "dependencies": {
-   },
-   "keywords": [
-      "msbuild",
-      "nuget",
-      "unity",
-      "dependencies",
-      "external",
-      "visual studio",
-      "C#",
-      "projects",
-      "PackageReference",
-      "ProjectReference"
+    "dependencies": {},
+    "keywords": [
+        "msbuild",
+        "nuget",
+        "unity",
+        "dependencies",
+        "external",
+        "visual studio",
+        "C#",
+        "projects",
+        "PackageReference",
+        "ProjectReference"
     ],
     "author": {
-      "name": "Microsoft",
-      "email": "ryan.tremblay@microsoft.com",
-      "url": "https://github.com/microsoft/MSBuildForUnity"
-    } 
+        "name": "Microsoft",
+        "email": "ryan.tremblay@microsoft.com",
+        "url": "https://github.com/microsoft/MSBuildForUnity"
+    }
 }


### PR DESCRIPTION
This change does a couple of things:
- Upgrades versions, and fixes MSB4U_RevisionVersion_PreIncrement to reference MSB4U_RevisionVersion instead of specifying duplicate versions. (This is done before the increment).
- Updates the increment not to happen on prerelease versions.
- Updates README.md a bit.