### PR TITLE
Update UPM Increment Logic

### DIFF
--- a/AzurePipelines/Publish.UPM.yml
+++ b/AzurePipelines/Publish.UPM.yml
@@ -19,15 +19,15 @@ steps:
   inputs:
     filePath: 'Scripts/IncrementUPMVersion.ps1'
     arguments: '-IncrementPatch -PrereleaseID $(Build.BuildNumber)'
-  displayName: 'Increment Version Patch Value (Non Release/Prerelease Branch)`
-  
+  displayName: 'Increment Version Patch Value (Non Release/Prerelease Branch)'
+
 - task: PowerShell@2
   condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/prerelease/')
   inputs:
     filePath: 'Scripts/IncrementUPMVersion.ps1'
     arguments: '-PrereleaseID $(Build.BuildNumber)'
-  displayName: 'Set Prerelease Version (Prerelease Branch)`
-  
+  displayName: 'Increment Version Patch Value (Non Release/Prerelease Branch)'
+
 - task: Npm@1
   inputs:
     command: 'publish'

--- a/AzurePipelines/Publish.UPM.yml
+++ b/AzurePipelines/Publish.UPM.yml
@@ -14,14 +14,19 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
-- task: Npm@1
-# Only update the version on master branch
+- task: PowerShell@2
   condition: and(not(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/prerelease/')))
   inputs:
-    command: 'custom'
-    customCommand: --no-git-tag-version version prerelease --preid=$(Build.BuildNumber)
-    workingDir: 'Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity'
-  displayName: 'Update UPM Version'
+    filePath: 'Scripts/IncrementUPMVersion.ps1'
+    arguments: '-IncrementPatch -PrereleaseID $(Build.BuildNumber)'
+  displayName: 'Increment Version Patch Value (Non Release/Prerelease Branch)`
+  
+- task: PowerShell@2
+  condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/prerelease/')
+  inputs:
+    filePath: 'Scripts/IncrementUPMVersion.ps1'
+    arguments: '-PrereleaseID $(Build.BuildNumber)'
+  displayName: 'Set Prerelease Version (Prerelease Branch)`
   
 - task: Npm@1
   inputs:

--- a/AzurePipelines/Scripts/IncrementUPMVersion.ps1
+++ b/AzurePipelines/Scripts/IncrementUPMVersion.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+    This script is used by the pipeline to append the prerelease id to the UPM package, and optionally increment the minor version.
+.DESCRIPTION
+    This script is used by the pipeline to append the prerelease id to the UPM package, and optionally increment the minor version.
+.PARAMETER PrereleaseID
+    The prerelease ID to set.
+.PARAMETER IncrementPatch
+    Whether to increment the minor version.
+#>
+param(
+    [string]$PrereleaseID,
+    [switch]$IncrementPatch
+)
+
+function Get-ScriptDirectory {
+    Split-Path -parent $PSCommandPath
+}
+
+$PathToPackage=Get-ScriptDirectory
+$PathToPackage=Join-Path $PathToPackage "..\..\Source\MSBuildTools.Unity\Packages\com.microsoft.msbuildforunity\package.json"
+$rawFileData = Get-Content -Raw -Path $PathToPackage
+$jsondata = $rawFileData | ConvertFrom-Json
+
+Write-Host "Original version in the file: $($jsondata.version)"
+$rawVersionParts = $jsondata.version -split "-"
+$version = [version]$rawVersionParts[0]
+Write-Host "Prerelease stripped version: $($version)"
+
+if ($IncrementPatch) {
+    $version = New-Object -TypeName System.Version -ArgumentList $version.Major, $version.Minor, ($version.Build + 1)
+}
+
+Write-Host "Post optional increment version: $($version)"
+
+$version = "{0}-{1}" -f $version, $PrereleaseID
+Write-Host "After appending pre-release id: $($version)"
+
+$rawFileData -replace $jsondata.version, $version | Out-File $PathToPackage


### PR DESCRIPTION
The new increment logic does the following:
- Increment the Patch version and set prerelease ID on all branches other than prerelease and release
- Set the prerelease ID on prerelease branches.