### PR TITLE
Fix README.md to point to the latest release of the MSBuildForUnity

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This scenario leverages the MSBuildForUnity [Project Builder](#msbuild-project-b
     - Add the following to the `dependencies` section of the file:
 
         ```json
-          "com.microsoft.msbuildforunity": "0.8.3"
+          "com.microsoft.msbuildforunity": "0.9.2-20200131.11"
         ```
 
 1. MSBuildForUnity will create a top-level project in your `Assets` folder named after your Unity project name: `{UnityProjectName}.Dependencies.msb4u.csproj`, edit this project file to add additional references to any NuGet packages or C# projects you want to use in your Unity project.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This scenario leverages the MSBuildForUnity [Project Builder](#msbuild-project-b
     - Add the following to the `dependencies` section of the file:
 
         ```json
-          "com.microsoft.msbuildforunity": "0.9.1"
+          "com.microsoft.msbuildforunity": "0.8.3"
         ```
 
 1. MSBuildForUnity will create a top-level project in your `Assets` folder named after your Unity project name: `{UnityProjectName}.Dependencies.msb4u.csproj`, edit this project file to add additional references to any NuGet packages or C# projects you want to use in your Unity project.


### PR DESCRIPTION
The version '0.9.1', being referred to in the README.md, throws an error while opening up the Unity project, indicating the aforementioned version does not exist. Changing it to the latest released version solves the problem.