### PR TITLE
Update samples to be compliant with NuGet security analysis in Azure pipelines

### DIFF
--- a/Samples/IntegratedDependencies.Unity/Assets/NuGet.config
+++ b/Samples/IntegratedDependencies.Unity/Assets/NuGet.config
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <!--
+      Manually uncomment to reference the special feed of MSBuildForUnity NuGet package. This requirement will go away soon.
     <add key="MSBuildForUnity" value="https://pkgs.dev.azure.com/UnityDeveloperTools/MSBuildForUnity/_packaging/UnityDeveloperTools/nuget/v3/index.json" />
+    -->
   </packageSources>
 </configuration>

--- a/Samples/SimpleNuGetDependency.Unity/Assets/NewtonsoftDependency/NuGet.config
+++ b/Samples/SimpleNuGetDependency.Unity/Assets/NewtonsoftDependency/NuGet.config
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <!--
+      Manually uncomment to reference the special feed of MSBuildForUnity NuGet package. This requirement will go away soon.
     <add key="MSBuildForUnity" value="https://pkgs.dev.azure.com/UnityDeveloperTools/MSBuildForUnity/_packaging/UnityDeveloperTools/nuget/v3/index.json" />
+    -->
   </packageSources>
 </configuration>

--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/NuGet.config
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/MSBuildTemplates/NuGet.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="MSBuildForUnity" value="https://pkgs.dev.azure.com/UnityDeveloperTools/MSBuildForUnity/_packaging/UnityDeveloperTools/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Update samples to be compliant with automatic NuGet security analysis injected in ADO pipelines. See https://aka.ms/nugetsecurityanalysis for more details but this essentially boils down to:
1. Ensuring `<clear/>` statements are in each nuget.config file in the repo
2. nuget.config only specifies a singular nuget feed

Since these are samples, the change adds 1 above and comments out references to the `MSBuildForUnity` feed with the expectation that one would uncomment them from the sample when testing this out manually. This is currently consistent with the documentation that a special feed for the MSBuildForUnity is currently required.
