### PR TITLE
Added support for project names with spaces

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectBuilder.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectBuilder/MSBuildProjectBuilder.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Build.Unity
 
         private static async Task<int> BuildProjectAsync(string projectPath, BuildEngine buildEngine, string arguments, IProgress<(string progressMessage, ProgressMessageType progressMessageType)> progress, CancellationToken cancellationToken)
         {
-            arguments = $"{Path.GetFileName(projectPath)} -restore {arguments}";
+            arguments = $"\"{Path.GetFileName(projectPath)}\" -restore {arguments}";
             string msBuildPath = null;
 
             switch (buildEngine)


### PR DESCRIPTION
msbuild call was not quoted, so any space would break the build (either in the project name or the parent folder containing the project).
Fix #132.