### PR TITLE
Fix Utilities.cs crash with Unix directory separator

### DIFF
--- a/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Utilities.cs
+++ b/Source/MSBuildTools.Unity/Packages/com.microsoft.msbuildforunity/Editor/ProjectGenerator/Scripts/Utilities.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Build.Unity.ProjectGeneration
                 if (relativePath.Contains('@'))
                 {
                     string[] parts = relativePath.Split('@');
-                    relativePath = parts[0] + parts[1].Substring(parts[1].IndexOf('\\'));
+                    relativePath = parts[0] + parts[1].Substring(parts[1].IndexOf(Path.DirectorySeparatorChar));
                 }
             }
             else if (path.Contains(PackagesPath))


### PR DESCRIPTION
On macOS (and probably on Linux) `GetAssetImporter` crashes because it expects backslashes in paths, but gets forward slashes. As far as I can tell this code path is only triggered when there is a `.csproj` file in a Unity Package Manager dependency of your Unity project. This PR uses the platform-native separator character instead of hardcoded backslash.